### PR TITLE
Fix stack init and keyword overflow

### DIFF
--- a/lexer.c
+++ b/lexer.c
@@ -229,7 +229,7 @@ Token *generate_number(char *current, int *current_index){
 Token *generate_keyword_or_identifier(char *current, int *current_index){
   Token *token = malloc(sizeof(Token));
   token->line_num = line_number;
-  char *keyword = malloc(sizeof(char) * 8);
+  char *keyword = malloc(sizeof(char) * 64);
   int keyword_index = 0;
   while(isalpha(current[*current_index]) && current[*current_index] != '\0'){
     keyword[keyword_index] = current[*current_index];

--- a/parser.c
+++ b/parser.c
@@ -521,6 +521,7 @@ Node *parser(Token *tokens){
   //Node *close_curly = malloc(sizeof(Node));
 
   curly_stack *stack = malloc(sizeof(curly_stack));
+  stack->top = -1;
 
   while(current_token->type != END_OF_TOKENS){
     if(current == NULL){


### PR DESCRIPTION
## Summary
- prevent heap overflow when lexing identifiers by allocating a larger buffer
- initialize parser curly brace stack before use

## Testing
- `./build_asan.sh`
- `./build/hsu_asan testing/test.hs` (shows only memory leaks, no crashes)
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_687903e3cd0c8333921dfcecc927cfd3