### PR TITLE
Improve parser to handle expressions and control flow

### DIFF
--- a/lexer.c
+++ b/lexer.c
@@ -232,8 +232,10 @@ Token *generate_keyword_or_identifier(char *current, int *current_index){
   char *keyword = malloc(sizeof(char) * 64);
   int keyword_index = 0;
   while(isalpha(current[*current_index]) && current[*current_index] != '\0'){
-    keyword[keyword_index] = current[*current_index];
-    keyword_index++;
+    if(keyword_index < 63){
+      keyword[keyword_index] = current[*current_index];
+      keyword_index++;
+    }
     *current_index += 1;
   }
   keyword[keyword_index] = '\0';
@@ -385,31 +387,37 @@ Token *lexer(FILE *file) {
       tokens[tokens_index] = *token;
       free(token);
       tokens_index++;
+      current_index--;
     } else if (current[current_index] == '|' && current[current_index + 1] == '|') {
       token = generate_two_char_operator(current, &current_index, OR);
       tokens[tokens_index] = *token;
       free(token);
       tokens_index++;
+      current_index--;
     } else if (current[current_index] == '+' && current[current_index + 1] == '+') {
       token = generate_two_char_operator(current, &current_index, PLUS_PLUS);
       tokens[tokens_index] = *token;
       free(token);
       tokens_index++;
+      current_index--;
     } else if (current[current_index] == '-' && current[current_index + 1] == '-') {
       token = generate_two_char_operator(current, &current_index, MINUS_MINUS);
       tokens[tokens_index] = *token;
       free(token);
       tokens_index++;
+      current_index--;
     } else if (current[current_index] == '+' && current[current_index + 1] == '=') {
       token = generate_two_char_operator(current, &current_index, PLUS_EQUALS);
       tokens[tokens_index] = *token;
       free(token);
       tokens_index++;
+      current_index--;
     } else if (current[current_index] == '-' && current[current_index + 1] == '=') {
       token = generate_two_char_operator(current, &current_index, MINUS_EQUALS);
       tokens[tokens_index] = *token;
       free(token);
       tokens_index++;
+      current_index--;
     }
     else if (current[current_index] == ';') {
       token = generate_separator_or_operator(current, &current_index, SEMICOLON);

--- a/main.c
+++ b/main.c
@@ -9,28 +9,24 @@
 
 void print_tokens(Token *t) {
   size_t i = 0;
-  while(t[i].value != NULL){
+  while(t[i].type != END_OF_TOKENS){
     print_token(t[i]);
     i++;
   }
 }
 
 int main(int argc, char *argv[]) {
-  FILE *file;
-  file = fopen(argv[1], "r");
-
+  FILE *file = fopen(argv[1], "r");
   if(!file){
     printf("ERROR: File not found\n");
     exit(1);
   }
-
   Token *tokens = lexer(file);
-  
   print_tokens(tokens);
-  
   Node *root = parser(tokens);
-  
   printf("Printing AST (Abstract Syntax Tree):\n");
   print_tree(root, 0, "Root", 0);
-  
+  free_tree(root);
+  free(tokens);
+  return 0;
 }

--- a/parser.c
+++ b/parser.c
@@ -1,631 +1,305 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
+#include <stdbool.h>
 
 #include "lexer.h"
 #include "tools.h"
 
-#define MAX_CURLY_STACK_LENGTH 64
-
 typedef struct Node {
-  char *value;
-  TokenType type;
-  struct Node *right;
-  struct Node *left;
+    char *value;
+    TokenType type;
+    struct Node *left;
+    struct Node *right;
 } Node;
 
-typedef struct {
-  Node *content[MAX_CURLY_STACK_LENGTH];
-  int top;
-} curly_stack;
+static Token *tokens;
+static size_t current;
 
-Node *peek_curly(curly_stack *stack){
-  return stack->content[stack->top];
+static Token *peek(void) { return &tokens[current]; }
+static Token *previous(void) { return &tokens[current-1]; }
+static bool check(TokenType type) { return peek()->type == type; }
+static Token *advance_token(void) {
+    if(peek()->type != END_OF_TOKENS) current++;
+    return previous();
+}
+static bool match(TokenType type) {
+    if(check(type)) { advance_token(); return true; }
+    return false;
 }
 
-void push_curly(curly_stack *stack, Node *element){
-  stack->top++;
-  stack->content[stack->top] = element;
-}
-
-Node *pop_curly(curly_stack *stack){
-  Node *result = stack->content[stack->top];
-  stack->top--;
-  return result;
-}
-
-void print_tree(Node *node, int indent, char *identifier) {
-    if (node == NULL) {
-        return;
-    }
-
-    for (int i = 0; i < indent; i++) {
-        printf(" ");
-    }
-    printf("%s -> %s\n", identifier, node->value ? node->value : "NULL");
-
-    indent += 4;
-
-    if (node->left) {
-        print_tree(node->left, indent, "├── left");
-    }
-
-    if (node->right) {
-        print_tree(node->right, indent, "└── right");
-    }
-}
-
-Node *init_node(Node *node, char *value, TokenType type){
-  node = malloc(sizeof(Node));
-  node->value = malloc(sizeof(char) * 2);
-  node->type = (int)type;
-  node->value = value;
-  node->left = NULL;
-  node->right = NULL;
-  return node;
-}
-
-void print_error(char *error_type, size_t line_number){
-  printf("ERROR: %s on line number: %zu\n", error_type, line_number);
-  exit(1);
-}
-
-Node *parse_expression(Token *current_token){
-  Node *expr_node = malloc(sizeof(Node));
-  expr_node = init_node(expr_node, current_token->value, current_token->type);
-  current_token++;
-  if(!is_operator(current_token->type)){
-    return expr_node;
-  }
-  return expr_node;
-}
-
-Token *generate_operation_nodes(Token *current_token, Node *current_node){
-  Node *oper_node = malloc(sizeof(Node));
-  oper_node = init_node(oper_node, current_token->value, current_token->type);
-  current_node->left->left = oper_node;
-  current_node = oper_node;
-  current_token--;
-  if(current_token->type == INT){
-    Node *expr_node = malloc(sizeof(Node));
-    expr_node = init_node(expr_node, current_token->value, INT);
-    current_node->left = expr_node;
-  } else if(current_token->type == IDENTIFIER){
-    Node *identifier_node = malloc(sizeof(Node));
-    identifier_node = init_node(identifier_node, current_token->value, IDENTIFIER);
-    current_node->left = identifier_node;
-  } else {
-    printf("ERROR: expected int or identifier\n");
+static void error(const char *msg, size_t line){
+    printf("ERROR: %s on line number: %zu\n", msg, line);
     exit(1);
-  }
-  current_token++;
-  current_token++;
-  while(current_token->type == INT || current_token->type == IDENTIFIER || is_operator(current_token->type)){
-    if(current_token->type == INT || current_token->type == IDENTIFIER){
-      if((current_token->type != INT && current_token->type != IDENTIFIER) || current_token == NULL){
-        printf("Syntax Error hERE\n");
-        exit(1);
-      }
-      current_token++;
-      if(!is_operator(current_token->type)){
-        current_token--;
-        if(current_token->type == INT){
-          Node *second_expr_node = malloc(sizeof(Node));
-          second_expr_node = init_node(second_expr_node, current_token->value, INT);
-          current_node->right = second_expr_node;
-        } else if(current_token->type == IDENTIFIER){
-          Node *second_identifier_node = malloc(sizeof(Node));
-          second_identifier_node = init_node(second_identifier_node, current_token->value, IDENTIFIER);
-          current_node->right = second_identifier_node;
-        } else {
-          printf("ERROR: Expected Integer or Identifier\n");
-          exit(1);
-        }
-      }
-    }
-    if(is_operator(current_token->type)){
-      Node *next_oper_node = malloc(sizeof(Node));
-      next_oper_node = init_node(next_oper_node, current_token->value, current_token->type);
-      current_node->right = next_oper_node;
-      current_node = next_oper_node;
-      current_token--;
-      if(current_token->type == INT){
-        Node *second_expr_node = malloc(sizeof(Node));
-        second_expr_node = init_node(second_expr_node, current_token->value, INT);
-        current_node->left = second_expr_node;
-      } else if(current_token->type == IDENTIFIER){
-        Node *second_identifier_node = malloc(sizeof(Node));
-        second_identifier_node = init_node(second_identifier_node, current_token->value, IDENTIFIER);
-        current_node->left = second_identifier_node;
-      } else {
-        printf("ERROR: Expected IDENTIFIER or INT\n");
-        exit(1);
-      }
-      current_token++; 
-    }
-    current_token++;
-  }
-  return current_token;
 }
 
-Node *handle_exit_syscall(Token *current_token, Node *current){
-    Node *exit_node = malloc(sizeof(Node));
-    exit_node = init_node(exit_node, current_token->value, EXIT);
-    current->right = exit_node;
-    current = exit_node;
-    current_token++;
-
-    if(current_token->type == END_OF_TOKENS){
-      print_error("Invalid Syntax on OPEN", current_token->line_num);
-    }
-    if(current_token->type == OPEN_PAREN){
-      Node *open_paren_node = malloc(sizeof(Node));
-      open_paren_node = init_node(open_paren_node, current_token->value, OPEN_PAREN);
-      current->left = open_paren_node;
-      current_token++;
-      if(current_token->type == END_OF_TOKENS){
-        print_error("Invalid Syntax on INT", current_token->line_num);
-      }
-      if(current_token->type == INT || current_token->type == IDENTIFIER){
-        current_token++;
-        if(is_operator(current_token->type) && current_token != NULL){
-          current_token = generate_operation_nodes(current_token, current);
-          current_token--;
-        } else {
-          current_token--;
-          Node *expr_node = malloc(sizeof(Node));
-          expr_node = init_node(expr_node, current_token->value, current_token->type);
-          current->left->left = expr_node;
-        }
-        current_token++;
-        if(current_token->type == END_OF_TOKENS){
-          print_error("Invalid Syntax on cLOSE", current_token->line_num);
-        }
-        if(current_token->type == CLOSE_PAREN && current_token->type != END_OF_TOKENS){
-          Node *close_paren_node = malloc(sizeof(Node));
-          close_paren_node = init_node(close_paren_node, current_token->value, CLOSE_PAREN);
-          current->left->right = close_paren_node;
-          current_token++;
-          if(current_token->type == END_OF_TOKENS){
-            print_error("Invalid Syntax on SEMI", current_token->line_num);
-          }
-          if(current_token->type == SEMICOLON){
-            Node *semi_node = malloc(sizeof(Node));
-            semi_node = init_node(semi_node, current_token->value, SEMICOLON);
-            current->right = semi_node;
-            current = semi_node;
-          } else {
-            print_error("Invalid Syntax on SEMI", current_token->line_num);
-          }
-        } else {
-            print_error("Invalid Syntax on CLOSE", current_token->line_num);
-        }
-      } else {
-        print_error("Invalid Syntax INT", current_token->line_num);
-      }
-  } else {
-    print_error("Invalid Syntax OPEN", current_token->line_num);
-  }
-  return current;
+static Node *new_node(Token *t){
+    Node *n = malloc(sizeof(Node));
+    n->value = t->value;
+    n->type = t->type;
+    n->left = n->right = NULL;
+    return n;
 }
 
-void handle_token_errors(char *error_text, Token *current_token, bool isType){
-  if(current_token->type == END_OF_TOKENS || !isType){
-    print_error(error_text, current_token->line_num);
-  }
+static Node *parse_expression(void);
+static Node *parse_statement(void);
+static Node *parse_block(void);
+
+static void expect(TokenType type, const char *msg){
+    if(!match(type)) error(msg, peek()->line_num);
 }
 
-Node *create_variable_reusage(Token *current_token, Node *current){
-  Node *main_identifier_node = malloc(sizeof(Node));
-  main_identifier_node = init_node(main_identifier_node, current_token->value, IDENTIFIER);
-  current->left = main_identifier_node;
-  current = main_identifier_node;
-  current_token++;
+/* Expression parsing with precedence */
 
-  handle_token_errors("Invalid syntax after idenfitier", current_token, is_operator(current_token->type));
-
-  if(is_operator(current_token->type)){
-    if(current_token->type == ASSIGNMENT){
-      print_error("Invalid Variable Syntax on =", current_token->line_num);
+static Node *parse_primary(void){
+    if(match(IDENTIFIER) || match(INT) || match(STRING)){
+        return new_node(previous());
     }
-    Node *equals_node = malloc(sizeof(Node));
-    equals_node = init_node(equals_node, current_token->value, current_token->type);
-    current->left = equals_node;
-    current = equals_node;
-    current_token++;
-  }
-  if(current_token->type == END_OF_TOKENS || (current_token->type != INT && current_token->type != IDENTIFIER)){
-    print_error("Invalid Syntax After Equals", current_token->line_num);
-  }
-
-  current_token++;
-  if(is_operator(current_token->type)){
-    Node *oper_node = malloc(sizeof(Node));
-    oper_node = init_node(oper_node, current_token->value, current_token->type);
-    current->left = oper_node;
-    current = oper_node;
-    current_token--;
-    if(current_token->type == INT){
-      Node *expr_node = malloc(sizeof(Node));
-      expr_node = init_node(expr_node, current_token->value, INT);
-      oper_node->left = expr_node;
-      current_token++;
-      current_token++;
-    } else if(current_token->type == IDENTIFIER){
-      Node *identifier_node = malloc(sizeof(Node));
-      identifier_node = init_node(identifier_node, current_token->value, IDENTIFIER);
-      oper_node->left = identifier_node;
-      current_token++;
-      current_token++;
-    } else {
-      print_error("ERROR: Expected IDENTIFIER or INT", current_token->line_num);
+    if(match(OPEN_PAREN)){
+        Node *expr = parse_expression();
+        expect(CLOSE_PAREN, "Invalid Syntax on CLOSE");
+        return expr;
     }
-    current_token++;
-
-    if(is_operator(current_token->type)){
-      Node *oper_node = malloc(sizeof(Node));
-      oper_node = init_node(oper_node, current_token->value, current_token->type);
-      current->right = oper_node;
-      current = oper_node;
-      int operation = 1;
-      current_token--;
-      current_token--;
-      while(operation){
-        current_token++;
-        if(current_token->type == INT){
-          Node *expr_node = malloc(sizeof(Node));
-          expr_node = init_node(expr_node, current_token->value, INT);
-          current->left = expr_node;
-        } else if(current_token->type == IDENTIFIER){
-          Node *identifier_node = malloc(sizeof(Node));
-          identifier_node = init_node(identifier_node, current_token->value, IDENTIFIER);
-          current->left = identifier_node;
-        } else {
-          print_error("ERROR: Unexpected Token\n", current_token->line_num);
-          exit(1);
-        }
-        current_token++;
-        if(is_operator(current_token->type)){
-          current_token++;
-          current_token++;
-          if(!is_operator(current_token->type)){
-            current_token--;
-            if(current_token->type == INT){
-              Node *expr_node = malloc(sizeof(Node));
-              expr_node = init_node(expr_node, current_token->value, INT);
-              current->right = expr_node;
-              current_token++;
-            } else if(current_token->type == IDENTIFIER){
-              Node *identifier_node = malloc(sizeof(Node));
-              identifier_node = init_node(identifier_node, current_token->value, IDENTIFIER);
-              current->right = identifier_node;
-              current_token++;
-            } else {
-              printf("ERROR: UNRECOGNIZED TOKEN!\n");
-              exit(1);
-            }
-            operation = 0;
-          } else {
-            current_token--;
-            current_token--;
-            Node *oper_node = malloc(sizeof(Node));
-            oper_node = init_node(oper_node, current_token->value, current_token->type);
-            current->right = oper_node;
-            current = oper_node;
-          }
-        } else {
-          operation = 0;
-        }
-      }
-    } else {
-      current_token--;
-      if(current_token->type == INT){
-        Node *expr_node = malloc(sizeof(Node));
-        expr_node = init_node(expr_node, current_token->value, INT);
-        oper_node->right = expr_node;
-      } else if(current_token->type == IDENTIFIER){
-        Node *identifier_node = malloc(sizeof(Node));
-        identifier_node = init_node(identifier_node, current_token->value, IDENTIFIER);
-        oper_node->right = identifier_node;
-      }
-      current_token++;
-    }
-  } else {
-    current_token--;
-    if(current_token->type == INT){
-      Node *expr_node = malloc(sizeof(Node));
-      expr_node = init_node(expr_node, current_token->value, INT);
-      current->left = expr_node;
-      current_token++;
-    } else if(current_token->type == IDENTIFIER){
-      Node *identifier_node = malloc(sizeof(Node));
-      identifier_node = init_node(identifier_node, current_token->value, IDENTIFIER);
-      current->left = identifier_node;
-      current_token++;
-    }
-  }
-  handle_token_errors("Invalid Syntax After Expression", current_token, is_separator(current_token->type));
-
-  current = main_identifier_node;
-  if(current_token->type == SEMICOLON){
-    Node *semi_node = malloc(sizeof(Node));
-    semi_node = init_node(semi_node, current_token->value, SEMICOLON);
-    current->right = semi_node;
-    current = semi_node;
-  }
-  return current;
+    error("Invalid Expression", peek()->line_num);
+    return NULL;
 }
 
-Node *create_variables(Token *current_token, Node *current){
-  Node *var_node = malloc(sizeof(Node));
-  var_node = init_node(var_node, current_token->value, current_token->type);
-  current->left = var_node;
-  current = var_node;
-  current_token++;
-  handle_token_errors("Invalid syntax after INT", current_token, current_token->type == IDENTIFIER);
-  if(current_token->type == IDENTIFIER){
-    Node *identifier_node = malloc(sizeof(Node));
-    identifier_node = init_node(identifier_node, current_token->value, IDENTIFIER);
-    current->left = identifier_node;
-    current = identifier_node;
-    current_token++;
-  }
-  handle_token_errors("Invalid Syntax After Identifier", current_token, is_operator(current_token->type));
-
-  if(is_operator(current_token->type)){
-    if(current_token->type != ASSIGNMENT){
-      print_error("Invalid Variable Syntax on =", current_token->line_num);
+static Node *parse_postfix(void){
+    Node *node = parse_primary();
+    while(match(PLUS_PLUS) || match(MINUS_MINUS)){
+        Node *op = new_node(previous());
+        op->left = node;
+        node = op;
     }
-    Node *equals_node = malloc(sizeof(Node));
-    equals_node = init_node(equals_node, current_token->value, current_token->type);
-    current->left = equals_node;
-    current = equals_node;
-    current_token++;
-  }
-  if(current_token->type == END_OF_TOKENS || (current_token->type != INT && current_token->type != IDENTIFIER)){
-    print_error("Invalid Syntax After Equals", current_token->line_num);
-  }
-
-  current_token++;
-  if(is_operator(current_token->type)){
-    Node *oper_node = malloc(sizeof(Node));
-    oper_node = init_node(oper_node, current_token->value, current_token->type);
-    current->left = oper_node;
-    current = oper_node;
-    current_token--;
-    if(current_token->type == INT){
-      Node *expr_node = malloc(sizeof(Node));
-      expr_node = init_node(expr_node, current_token->value, INT);
-      oper_node->left = expr_node;
-      current_token++;
-      current_token++;
-    } else if(current_token->type == IDENTIFIER){
-      Node *identifier_node = malloc(sizeof(Node));
-      identifier_node = init_node(identifier_node, current_token->value, IDENTIFIER);
-      oper_node->left = identifier_node;
-      current_token++;
-      current_token++;
-    } else {
-      print_error("ERROR: Expected IDENTIFIER or INT", current_token->line_num);
-    }
-    current_token++;
-
-    if(is_operator(current_token->type)){
-      Node *oper_node = malloc(sizeof(Node));
-      oper_node = init_node(oper_node, current_token->value, current_token->type);
-      current->right = oper_node;
-      current = oper_node;
-      int operation = 1;
-      current_token--;
-      current_token--;
-      while(operation){
-        current_token++;
-        if(current_token->type == INT){
-          Node *expr_node = malloc(sizeof(Node));
-          expr_node = init_node(expr_node, current_token->value, INT);
-          current->left = expr_node;
-        } else if(current_token->type == IDENTIFIER){
-          Node *identifier_node = malloc(sizeof(Node));
-          identifier_node = init_node(identifier_node, current_token->value, IDENTIFIER);
-          current->left = identifier_node;
-        } else {
-          printf("ERROR: Unexpected Token\n");
-          exit(1);
-        }
-        current_token++;
-        if(is_operator(current_token->type)){
-          current_token++;
-          current_token++;
-          if(!is_operator(current_token->type)){
-            current_token--;
-            if(current_token->type == INT){
-              Node *expr_node = malloc(sizeof(Node));
-              expr_node = init_node(expr_node, current_token->value, INT);
-              current->right = expr_node;
-              current_token++;
-            } else if(current_token->type == IDENTIFIER){
-              Node *identifier_node = malloc(sizeof(Node));
-              identifier_node = init_node(identifier_node, current_token->value, IDENTIFIER);
-              current->right = identifier_node;
-              current_token++;
-            } else {
-              printf("ERROR: UNRECOGNIZED TOKEN!\n");
-              exit(1);
-            }
-            operation = 0;
-          } else {
-            current_token--;
-            current_token--;
-            Node *oper_node = malloc(sizeof(Node));
-            oper_node = init_node(oper_node, current_token->value, current_token->type);
-            current->right = oper_node;
-            current = oper_node;
-          }
-        } else {
-          operation = 0;
-        }
-      }
-    } else {
-      current_token--;
-      if(current_token->type == INT){
-        Node *expr_node = malloc(sizeof(Node));
-        expr_node = init_node(expr_node, current_token->value, INT);
-        oper_node->right = expr_node;
-      } else if(current_token->type == IDENTIFIER){
-        Node *identifier_node = malloc(sizeof(Node));
-        identifier_node = init_node(identifier_node, current_token->value, IDENTIFIER);
-        oper_node->right = identifier_node;
-      }
-      current_token++;
-    }
-  } else {
-    current_token--;
-    if(current_token->type == INT){
-      Node *expr_node = malloc(sizeof(Node));
-      expr_node = init_node(expr_node, current_token->value, INT);
-      current->left = expr_node;
-      current_token++;
-    } else if(current_token->type == IDENTIFIER){
-      Node *identifier_node = malloc(sizeof(Node));
-      identifier_node = init_node(identifier_node, current_token->value, IDENTIFIER);
-      current->left = identifier_node;
-      current_token++;
-    }
-  }
-
-  //if(current_token->type == OPERATOR){
-  //  current_token = generate_operation_nodes(current_token, current);
-  //}
-
-  handle_token_errors("Invalid Syntax After Expression", current_token, is_separator(current_token->type));
-
-  current = var_node;
-  if(current_token->type == SEMICOLON){
-    Node *semi_node = malloc(sizeof(Node));
-    semi_node = init_node(semi_node, current_token->value, SEMICOLON);
-    current->right = semi_node;
-    current = semi_node;
-  }
-  return current;
+    return node;
 }
 
-Node *parser(Token *tokens){
-  Token *current_token = &tokens[0];
-  Node *root = malloc(sizeof(Node));
-  root = init_node(root, "PROGRAM", BEGINNING);
-
-  Node *current = root;
-
-  Node *open_curly = malloc(sizeof(Node));
-  //Node *close_curly = malloc(sizeof(Node));
-
-  curly_stack *stack = malloc(sizeof(curly_stack));
-  stack->top = -1;
-
-  while(current_token->type != END_OF_TOKENS){
-    if(current == NULL){
-      break;
+static Node *parse_factor(void){
+    Node *node = parse_postfix();
+    while(match(STAR) || match(SLASH) || match(PERCENT)){
+        Node *op = new_node(previous());
+        op->left = node;
+        op->right = parse_postfix();
+        node = op;
     }
-    switch(current_token->type){
-      case LET:
-      case FN:
-      case IF:
-      case ELSE_IF:
-      case ELSE:
-      case FOR:
-      case FOR_EACH:
-      case WHILE:
-      case WRITE:
-      case EXIT:
-        if(current_token->type == LET){
-          current = create_variables(current_token, current);
-        } else if(current_token->type == FN){
-          //handle function creation
-        } else if(current_token->type == IF){
-          //handle if statement creation
-        } else if(current_token->type == ELSE_IF){
-          //handle else if creation
-        } else if(current_token->type == ELSE){
-          //handle else creation
-        } else if(current_token->type == FOR_EACH){
-          //handle for each creation
-        } else if(current_token->type == WHILE){
-          //handle while loop creation
-        } else if(current_token->type == WRITE){
-          //handle write creation
-        } else if(current_token->type == EXIT){
-          current = handle_exit_syscall(current_token, current);
-        }
-        break;
-      case OPEN_CURLY:
-      case CLOSE_CURLY:
-      case OPEN_BRACKET:
-      case CLOSE_BRACKET:
-      case OPEN_PAREN:
-      case CLOSE_PAREN:
-      case SEMICOLON:
-      case COMMA:
-        if(current_token->type == OPEN_CURLY){
-          Token *temp = current_token;
-          open_curly = init_node(open_curly, temp->value, OPEN_CURLY);
-          current->left = open_curly;
-          current = open_curly;
-          push_curly(stack, open_curly);
-          current = peek_curly(stack);
-        }
-        if(current_token->type == CLOSE_CURLY){
-          Node *close_curly = malloc(sizeof(Node));
-          open_curly = pop_curly(stack);
-          if(open_curly == NULL){
-            printf("ERROR: Expected Open Parenthesis!\n");
-            exit(1);
-          }
-          close_curly = init_node(close_curly, current_token->value, current_token->type);
-          current->right = close_curly;
-          current = close_curly;
-        }
-        break; 
-      case ASSIGNMENT:
-      case NOT:
-      case PLUS_PLUS:
-      case MINUS_MINUS:
-      case PLUS_EQUALS:
-      case MINUS_EQUALS:
-      case PLUS:
-      case DASH:
-      case SLASH:
-      case STAR:
-      case PERCENT:
-        break;
-      case INT:
-        break;
-      case IDENTIFIER:
-        current_token--;
-        if(current_token->type == SEMICOLON || current_token->type == OPEN_CURLY || current_token->type == CLOSE_CURLY){
-          current_token++;
-          current = create_variable_reusage(current_token, current);
-        } else {
-          current_token++;
-        }
-        break;
-      case STRING:
-        break;
-      case OR:
-      case AND:
-      case LESS:
-      case LESS_EQUALS:
-      case GREATER:
-      case GREATER_EQUALS:
-      case EQUALS:
-      case NOT_EQUALS:
-        break;
-      case BEGINNING:
-        break;
-      case END_OF_TOKENS:
-        break;
-    }
-    current_token++;
-  }
-  return root;
+    return node;
 }
+
+static Node *parse_term(void){
+    Node *node = parse_factor();
+    while(match(PLUS) || match(DASH)){
+        Node *op = new_node(previous());
+        op->left = node;
+        op->right = parse_factor();
+        node = op;
+    }
+    return node;
+}
+
+static Node *parse_comparison(void){
+    Node *node = parse_term();
+    while(match(LESS) || match(LESS_EQUALS) || match(GREATER) || match(GREATER_EQUALS)){
+        Node *op = new_node(previous());
+        op->left = node;
+        op->right = parse_term();
+        node = op;
+    }
+    return node;
+}
+
+static Node *parse_equality(void){
+    Node *node = parse_comparison();
+    while(match(EQUALS) || match(NOT_EQUALS)){
+        Node *op = new_node(previous());
+        op->left = node;
+        op->right = parse_comparison();
+        node = op;
+    }
+    return node;
+}
+
+static Node *parse_logic_and(void){
+    Node *node = parse_equality();
+    while(match(AND)){
+        Node *op = new_node(previous());
+        op->left = node;
+        op->right = parse_equality();
+        node = op;
+    }
+    return node;
+}
+
+static Node *parse_expression(void){
+    Node *node = parse_logic_and();
+    while(match(OR)){
+        Node *op = new_node(previous());
+        op->left = node;
+        op->right = parse_logic_and();
+        node = op;
+    }
+    return node;
+}
+
+/* Statement parsing */
+
+static Node *parse_let(void){
+    Token *let_tok = advance_token();
+    Node *let_node = new_node(let_tok);
+    expect(IDENTIFIER, "Invalid Syntax After LET");
+    Node *id_node = new_node(previous());
+    expect(ASSIGNMENT, "Invalid Variable Syntax on =");
+    Node *expr = parse_expression();
+    expect(SEMICOLON, "Invalid Syntax on SEMI");
+    let_node->left = id_node;
+    id_node->left = expr;
+    return let_node;
+}
+
+static Node *parse_write(void){
+    Token *w_tok = advance_token();
+    Node *w_node = new_node(w_tok);
+    expect(OPEN_PAREN, "Invalid Syntax on OPEN");
+    Node *expr = parse_expression();
+    expect(CLOSE_PAREN, "Invalid Syntax on CLOSE");
+    expect(SEMICOLON, "Invalid Syntax on SEMI");
+    w_node->left = expr;
+    return w_node;
+}
+
+static Node *parse_exit(void){
+    Token *e_tok = advance_token();
+    Node *e_node = new_node(e_tok);
+    expect(OPEN_PAREN, "Invalid Syntax on OPEN");
+    Node *expr = parse_expression();
+    expect(CLOSE_PAREN, "Invalid Syntax on CLOSE");
+    expect(SEMICOLON, "Invalid Syntax on SEMI");
+    e_node->left = expr;
+    return e_node;
+}
+
+static Node *parse_block(void){
+    expect(OPEN_CURLY, "Invalid Syntax on OPEN_CURLY");
+    Node *block = new_node(previous());
+    Node **current_ptr = &block->left;
+    while(!check(CLOSE_CURLY) && peek()->type != END_OF_TOKENS){
+        Node *stmt = parse_statement();
+        *current_ptr = stmt;
+        current_ptr = &stmt->right;
+    }
+    expect(CLOSE_CURLY, "Invalid Syntax on CLOSE_CURLY");
+    return block;
+}
+
+static Node *parse_if(void){
+    Token *if_tok = advance_token();
+    Node *if_node = new_node(if_tok);
+    expect(OPEN_PAREN, "Invalid Syntax on OPEN");
+    Node *cond = parse_expression();
+    expect(CLOSE_PAREN, "Invalid Syntax on CLOSE");
+    Node *body = parse_block();
+    if_node->left = cond;
+    cond->right = body;
+
+    Node *current_if = if_node;
+    while(match(ELSE_IF)){
+        Node *elif_node = new_node(previous());
+        expect(OPEN_PAREN, "Invalid Syntax on OPEN");
+        Node *elif_cond = parse_expression();
+        expect(CLOSE_PAREN, "Invalid Syntax on CLOSE");
+        Node *elif_body = parse_block();
+        current_if->right = elif_node;
+        elif_node->left = elif_cond;
+        elif_cond->right = elif_body;
+        current_if = elif_node;
+    }
+    if(match(ELSE)){
+        Node *else_node = new_node(previous());
+        Node *else_body = parse_block();
+        current_if->right = else_node;
+        else_node->left = else_body;
+    }
+    return if_node;
+}
+
+static Node *parse_for(void){
+    Token *for_tok = advance_token();
+    Node *for_node = new_node(for_tok);
+    expect(OPEN_PAREN, "Invalid Syntax on OPEN");
+    Node *init = parse_let();
+    Node *cond = parse_expression();
+    expect(SEMICOLON, "Invalid Syntax on SEMI");
+    Node *post = parse_expression();
+    expect(CLOSE_PAREN, "Invalid Syntax on CLOSE");
+    Node *body = parse_block();
+    for_node->left = init;
+    init->right = cond;
+    cond->right = post;
+    post->right = body;
+    return for_node;
+}
+
+static Node *parse_fn(void){
+    Token *fn_tok = advance_token();
+    Node *fn_node = new_node(fn_tok);
+    expect(IDENTIFIER, "Invalid Syntax after FN");
+    Node *id_node = new_node(previous());
+    expect(OPEN_PAREN, "Invalid Syntax on OPEN");
+    expect(CLOSE_PAREN, "Invalid Syntax on CLOSE");
+    Node *body = parse_block();
+    fn_node->left = id_node;
+    id_node->right = body;
+    return fn_node;
+}
+
+static Node *parse_statement(void){
+    switch(peek()->type){
+        case LET:
+            return parse_let();
+        case WRITE:
+            return parse_write();
+        case EXIT:
+            return parse_exit();
+        case FOR:
+            return parse_for();
+        case IF:
+            return parse_if();
+        case FN:
+            return parse_fn();
+        default:
+            error("Unexpected token", peek()->line_num);
+            return NULL;
+    }
+}
+
+Node *parser(Token *toks){
+    tokens = toks;
+    current = 0;
+    Node *program = malloc(sizeof(Node));
+    program->value = "PROGRAM";
+    program->type = BEGINNING;
+    program->left = program->right = NULL;
+    Node **current_ptr = &program->left;
+    while(peek()->type != END_OF_TOKENS){
+        Node *stmt = parse_statement();
+        *current_ptr = stmt;
+        current_ptr = &stmt->right;
+    }
+    return program;
+}
+
+void print_tree(Node *node, int indent, char *label, int is_last){
+    if(!node) return;
+    for(int i=0;i<indent;i++) printf(" ");
+    printf("%s -> %s\n", label, node->value ? node->value : "NULL");
+    indent += 4;
+    if(node->left) print_tree(node->left, indent, "├── left", node->right==NULL);
+    if(node->right) print_tree(node->right, indent, "└── right", 1);
+}
+
+void free_tree(Node *node){
+    if(!node) return;
+    free_tree(node->left);
+    free_tree(node->right);
+    free(node);
+}
+

--- a/parser.h
+++ b/parser.h
@@ -6,11 +6,12 @@
 typedef struct Node {
   char *value;
   TokenType type;
-  struct Node *right;
   struct Node *left;
+  struct Node *right;
 } Node;
 
 Node *parser(Token *tokens);
 void print_tree(Node *node, int indent, char *identifier, int is_last);
+void free_tree(Node *node);
 
 #endif

--- a/testing/parser/lexer.c
+++ b/testing/parser/lexer.c
@@ -209,7 +209,6 @@ void print_token(Token token){
 
 Token *generate_number(char *current, int *current_index){
   Token *token = malloc(sizeof(Token));
-  token->line_num = malloc(sizeof(size_t));
   token->line_num = line_number;
   token->type = INT;
   char *value = malloc(sizeof(char) * 8);
@@ -229,13 +228,14 @@ Token *generate_number(char *current, int *current_index){
 
 Token *generate_keyword_or_identifier(char *current, int *current_index){
   Token *token = malloc(sizeof(Token));
-  token->line_num = malloc(sizeof(size_t));
   token->line_num = line_number;
-  char *keyword = malloc(sizeof(char) * 8);
+  char *keyword = malloc(sizeof(char) * 64);
   int keyword_index = 0;
   while(isalpha(current[*current_index]) && current[*current_index] != '\0'){
-    keyword[keyword_index] = current[*current_index];
-    keyword_index++;
+    if(keyword_index < 63){
+      keyword[keyword_index] = current[*current_index];
+      keyword_index++;
+    }
     *current_index += 1;
   }
   keyword[keyword_index] = '\0';
@@ -293,7 +293,6 @@ Token *generate_keyword_or_identifier(char *current, int *current_index){
 
 Token *generate_string_token(char *current, int *current_index){
   Token *token = malloc(sizeof(Token));
-  token->line_num = malloc(sizeof(size_t));
   token->line_num = line_number;
   char *value = malloc(sizeof(char) * 64);
   int value_index = 0;
@@ -314,7 +313,6 @@ Token *generate_separator_or_operator(char *current, int *current_index, TokenTy
   token->value = malloc(sizeof(char) * 2);
   token->value[0] = current[*current_index];
   token->value[1] = '\0';
-  token->line_num = malloc(sizeof(size_t));
   token->line_num = line_number;
   token->type = type;
   return token;
@@ -327,7 +325,6 @@ Token *generate_two_char_operator(char *current, int *current_index, TokenType t
     token->value[1] = current[*current_index + 1];
     token->value[2] = '\0';
     *current_index += 2;
-    token->line_num = malloc(sizeof(size_t));
     token->line_num = line_number;
     token->type = type;
     return token;
@@ -335,7 +332,7 @@ Token *generate_two_char_operator(char *current, int *current_index, TokenType t
 
 size_t tokens_index;
 
-Token *lexer(FILE *file){
+Token *lexer(FILE *file) {
   int length;
   char *current = 0;
 
@@ -343,7 +340,7 @@ Token *lexer(FILE *file){
   length = ftell(file);
   fseek(file, 0, SEEK_SET);
 
-  current = malloc(sizeof(char) * length);
+  current = malloc(sizeof(char) * (length + 1));
   fread(current, 1, length, file);
 
   fclose(file);
@@ -356,142 +353,178 @@ Token *lexer(FILE *file){
   Token *tokens = malloc(sizeof(Token) * number_of_tokens);
   tokens_index = 0;
 
-  while(current[current_index] != '\0'){
-    Token *token = malloc(sizeof(Token));
+  while(current[current_index] != '\0') {
+    Token *token;
+    
     tokens_size++;
-    if(tokens_size > number_of_tokens){
+    if(tokens_size > number_of_tokens) {
       number_of_tokens *= 1.5;
       tokens = realloc(tokens, sizeof(Token) * number_of_tokens);
     }
-    if (current[current_index] == '=' && current[current_index + 1] == '='){
+
+    if (current[current_index] == '=' && current[current_index + 1] == '=') {
       token = generate_two_char_operator(current, &current_index, EQUALS);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
     } else if (current[current_index] == '!' && current[current_index + 1] == '=') {
       token = generate_two_char_operator(current, &current_index, NOT_EQUALS);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if (current[current_index] == '<' && current[current_index + 1] == '='){
-      token = generate_two_char_operator(current, &current_index, LESS_EQUALS); 
+    } else if (current[current_index] == '<' && current[current_index + 1] == '=') {
+      token = generate_two_char_operator(current, &current_index, LESS_EQUALS);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if (current[current_index] == '>' && current[current_index + 1] == '='){
-      token = generate_two_char_operator(current, &current_index, GREATER_EQUALS);  
+    } else if (current[current_index] == '>' && current[current_index + 1] == '=') {
+      token = generate_two_char_operator(current, &current_index, GREATER_EQUALS);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if (current[current_index] == '&' && current[current_index + 1] == '&'){
-      token = generate_two_char_operator(current, &current_index, AND);  
+    } else if (current[current_index] == '&' && current[current_index + 1] == '&') {
+      token = generate_two_char_operator(current, &current_index, AND);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if (current[current_index] == '|' && current[current_index + 1] == '|'){
+    } else if (current[current_index] == '|' && current[current_index + 1] == '|') {
       token = generate_two_char_operator(current, &current_index, OR);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if (current[current_index] == '+' && current[current_index + 1] == '+'){
+    } else if (current[current_index] == '+' && current[current_index + 1] == '+') {
       token = generate_two_char_operator(current, &current_index, PLUS_PLUS);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if (current[current_index] == '-' && current[current_index + 1] == '-'){
+    } else if (current[current_index] == '-' && current[current_index + 1] == '-') {
       token = generate_two_char_operator(current, &current_index, MINUS_MINUS);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if (current[current_index] == '+' && current[current_index + 1] == '='){
+    } else if (current[current_index] == '+' && current[current_index + 1] == '=') {
       token = generate_two_char_operator(current, &current_index, PLUS_EQUALS);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if (current[current_index] == '-' && current[current_index + 1] == '='){
+    } else if (current[current_index] == '-' && current[current_index + 1] == '=') {
       token = generate_two_char_operator(current, &current_index, MINUS_EQUALS);
       tokens[tokens_index] = *token;
-      tokens_index++; 
-    } else if(current[current_index] == ';'){
+      free(token);
+      tokens_index++;
+    }
+    else if (current[current_index] == ';') {
       token = generate_separator_or_operator(current, &current_index, SEMICOLON);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if(current[current_index] == ','){
+    } else if (current[current_index] == ',') {
       token = generate_separator_or_operator(current, &current_index, COMMA);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if(current[current_index] == '('){
+    } else if (current[current_index] == '(') {
       token = generate_separator_or_operator(current, &current_index, OPEN_PAREN);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if(current[current_index] == ')'){
+    } else if (current[current_index] == ')') {
       token = generate_separator_or_operator(current, &current_index, CLOSE_PAREN);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if(current[current_index] == '{'){
+    } else if (current[current_index] == '{') {
       token = generate_separator_or_operator(current, &current_index, OPEN_CURLY);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if(current[current_index] == '}'){
+    } else if (current[current_index] == '}') {
       token = generate_separator_or_operator(current, &current_index, CLOSE_CURLY);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if(current[current_index] == '='){
+    } else if (current[current_index] == '=') {
       token = generate_separator_or_operator(current, &current_index, ASSIGNMENT);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if(current[current_index] == '+'){
+    } else if (current[current_index] == '+') {
       token = generate_separator_or_operator(current, &current_index, PLUS);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if(current[current_index] == '-'){
+    } else if (current[current_index] == '-') {
       token = generate_separator_or_operator(current, &current_index, DASH);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if(current[current_index] == '*'){
+    } else if (current[current_index] == '*') {
       token = generate_separator_or_operator(current, &current_index, STAR);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if(current[current_index] == '/'){
+    } else if (current[current_index] == '/') {
       token = generate_separator_or_operator(current, &current_index, SLASH);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if(current[current_index] == '%'){
+    } else if (current[current_index] == '%') {
       token = generate_separator_or_operator(current, &current_index, PERCENT);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if(current[current_index] == '>'){
+    } else if (current[current_index] == '>') {
       token = generate_separator_or_operator(current, &current_index, GREATER);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if(current[current_index] == '<'){
+    } else if (current[current_index] == '<') {
       token = generate_separator_or_operator(current, &current_index, LESS);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if(current[current_index] == '['){
+    } else if (current[current_index] == '[') {
       token = generate_separator_or_operator(current, &current_index, OPEN_BRACKET);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if(current[current_index] == ']'){
+    } else if (current[current_index] == ']') {
       token = generate_separator_or_operator(current, &current_index, CLOSE_BRACKET);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if(current[current_index] == '!'){
+    } else if (current[current_index] == '!') {
       token = generate_separator_or_operator(current, &current_index, NOT);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if(current[current_index] == '"'){
+    }
+    else if (current[current_index] == '"') {
       token = generate_string_token(current, &current_index);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
-    } else if(isdigit(current[current_index])){
-      token = generate_number(current, &current_index); 
+    } else if (isdigit(current[current_index])) {
+      token = generate_number(current, &current_index);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
       current_index--;
-    } else if(isalpha(current[current_index])){
+    } else if (isalpha(current[current_index])) {
       token = generate_keyword_or_identifier(current, &current_index);
       tokens[tokens_index] = *token;
+      free(token);
       tokens_index++;
       current_index--;
-    } else if(current[current_index] == '\n'){
+    } else if (current[current_index] == '\n') {
       line_number += 1;
-    } 
-    free(token);
+    }
     current_index++;
   }
-  tokens[tokens_index].value = '\0';
+  tokens[tokens_index].value = NULL;
   tokens[tokens_index].type = END_OF_TOKENS;
+
+  free(current);
+
   return tokens;
 }


### PR DESCRIPTION
## Summary
- rewrite parser with recursive-descent expression parsing and control-flow nodes
- fix lexer skipping of tokens for two-character operators
- update driver to use new parser

## Testing
- `sh testing/parser/build.sh`
- `./parser_test testing/parser/test_parse.hs`
- `./parser_test testing/test.hs`
- `./parser_test testing/test2.hs`
- `./parser_test testing/test3.hs`
- `ASAN_OPTIONS=detect_leaks=1:halt_on_error=0 ./build/hsu_asan testing/test.hs` *(leaks reported)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f10777e08333b9adeb0d3751a446