### PR TITLE
Add basic x86 exit code generation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-gcc -Iinclude main.c lexer.c parser.c tools.c -o build/hsc -Wall -Wextra
+gcc -Iinclude main.c lexer.c parser.c tools.c codegen.c -o build/hsc -Wall -Wextra

--- a/build_asan.sh
+++ b/build_asan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 mkdir -p build
-gcc -Iinclude -c main.c lexer.c parser.c tools.c -fsanitize=address -g || { echo "Compilation failed"; exit 1; }
-gcc -Iinclude main.o lexer.o parser.o tools.o -o build/hsu_asan -fsanitize=address -static-libasan || { echo "Linking failed"; exit 1; }
-rm -f main.o lexer.o parser.o tools.o
+gcc -Iinclude -c main.c lexer.c parser.c tools.c codegen.c -fsanitize=address -g || { echo "Compilation failed"; exit 1; }
+gcc -Iinclude main.o lexer.o parser.o tools.o codegen.o -o build/hsu_asan -fsanitize=address -static-libasan || { echo "Linking failed"; exit 1; }
+rm -f main.o lexer.o parser.o tools.o codegen.o
 echo "Build completed successfully!"
 

--- a/codegen.c
+++ b/codegen.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include "parser.h"
+#include "codegen.h"
+
+static int has_exit = 0;
+
+static void emit_exit(Node *node, FILE *out) {
+    Node *paren = node->left;
+    Node *arg = paren ? paren->left : NULL;
+    const char *status = arg && arg->value ? arg->value : "0";
+    fprintf(out, "    mov rax, 60\n");
+    fprintf(out, "    mov rdi, %s\n", status);
+    fprintf(out, "    syscall\n");
+    has_exit = 1;
+}
+
+static void emit_node(Node *node, FILE *out) {
+    if (!node) return;
+    if (node->type == EXIT) {
+        emit_exit(node, out);
+    }
+    emit_node(node->left, out);
+    emit_node(node->right, out);
+}
+
+void generate_code(Node *root, const char *filename) {
+    FILE *out = fopen(filename, "w");
+    if (!out) {
+        perror("codegen");
+        return;
+    }
+    has_exit = 0;
+    fprintf(out, "section .text\n");
+    fprintf(out, "global _start\n");
+    fprintf(out, "_start:\n");
+    emit_node(root, out);
+    if (!has_exit) {
+        fprintf(out, "    mov rax, 60\n");
+        fprintf(out, "    mov rdi, 0\n");
+        fprintf(out, "    syscall\n");
+    }
+    fclose(out);
+}

--- a/include/codegen.h
+++ b/include/codegen.h
@@ -1,0 +1,8 @@
+#ifndef CODEGEN_H
+#define CODEGEN_H
+
+#include "parser.h"
+
+void generate_code(Node *root, const char *filename);
+
+#endif

--- a/main.c
+++ b/main.c
@@ -6,6 +6,7 @@
 #include "lexer.h"
 #include "parser.h"
 #include "tools.h"
+#include "codegen.h"
 
 void print_tokens(Token *t) {
   size_t i = 0;
@@ -29,8 +30,10 @@ int main(int argc, char *argv[]) {
   print_tokens(tokens);
   
   Node *root = parser(tokens);
-  
+
   printf("Printing AST (Abstract Syntax Tree):\n");
   print_tree(root, 0, "Root", 0);
-  
+
+  generate_code(root, "out.asm");
+
 }


### PR DESCRIPTION
## Summary
- start simple code generation pass that emits x86-64 exit syscall
- hook codegen into main and build scripts

## Testing
- `./build.sh`
- `./build/hsc test_cases/exit.hs`
- `./build/hsc test_cases/hello_world.hs`
- `./build/hsc test_cases/arithmetic.hs`
- `./build/hsc test_cases/strings.hs`


------
https://chatgpt.com/codex/tasks/task_e_68a9031dce5c833388a0a855623eae91