### PR TITLE
Refactor parser token handling

### DIFF
--- a/include/token_helpers.h
+++ b/include/token_helpers.h
@@ -1,0 +1,40 @@
+#ifndef TOKEN_HELPERS_H
+#define TOKEN_HELPERS_H
+
+#include "lexer.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static inline Token *peek(Token **pp) {
+  return *pp;
+}
+
+static inline Token *next(Token **pp) {
+  (*pp)++;
+  return *pp;
+}
+
+static inline Token *prev(Token **pp) {
+  (*pp)--;
+  return *pp;
+}
+
+static inline bool match(Token **pp, TokenType type) {
+  if ((*pp)->type != type)
+    return false;
+  (*pp)++;
+  return true;
+}
+
+static inline Token *expect(Token **pp, TokenType type, const char *msg) {
+  if ((*pp)->type != type) {
+    printf("ERROR: %s on line number: %zu\n", msg, (*pp)->line_num);
+    exit(1);
+  }
+  Token *t = *pp;
+  (*pp)++;
+  return t;
+}
+
+#endif


### PR DESCRIPTION
## Summary
- add token_helpers with peek/next/match/expect utilities
- refactor parser to use Token** and helper functions for token advancement
- remove direct pointer arithmetic on tokens and simplify variable/loop parsing

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a9efe4002083338d98db329730cebd