### PR TITLE
Implement Pratt-based expression parsing

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -4,17 +4,15 @@
 
 #include "lexer.h"
 
-// Kinds of AST nodes that may appear in the syntax tree.  The
-// enumeration purposefully covers high level program structure
-// (program and block), different statement kinds, literals and
-// generic operators.
+// Kinds of AST nodes that may appear in the syntax tree.
 typedef enum {
-  NODE_PROGRAM,
-  NODE_BLOCK,
-  NODE_WRITE_STMT,
-  NODE_EXIT_STMT,
-  NODE_BINARY_OP,
-  NODE_LITERAL,
+  NK_Program,
+  NK_Block,
+  NK_WriteStmt,
+  NK_ExitStmt,
+  NK_Unary,
+  NK_Binary,
+  NK_Literal,
 } NodeKind;
 
 // Forward declaration so we can reference Node inside Vec before the


### PR DESCRIPTION
## Summary
- add left-binding power table and Pratt `nud`/`parse_expr` expression parser
- parse `exit` arguments and identifier expressions using Pratt parser
- define new node kinds `NK_Unary` and `NK_Binary`

## Testing
- `bash build.sh`
- `./build/hsc test_cases/exit.hs`


------
https://chatgpt.com/codex/tasks/task_e_68a9f4beb7a08333ac0a2f74e9f05ea3