### PR TITLE
Refactor parser with block and statement parsers

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -8,6 +8,12 @@
 typedef enum {
   NK_Program,
   NK_Block,
+  NK_FnDecl,
+  NK_LetStmt,
+  NK_AssignStmt,
+  NK_IfStmt,
+  NK_WhileStmt,
+  NK_ForStmt,
   NK_WriteStmt,
   NK_ExitStmt,
   NK_Unary,


### PR DESCRIPTION
## Summary
- Parse `{...}` blocks into dynamic child vectors
- Add statement parser with dedicated handlers for `write`, `exit`, `let`, `if`, loops, and functions
- Wrap the file in an `NK_Program` node containing a single top-level `NK_Block`

## Testing
- `bash build.sh`
- `./build/hsc test_cases/hello_world.hs`
- `./build/hsc test_cases/fizzbuzz.hs`


------
https://chatgpt.com/codex/tasks/task_e_68a9f74350cc8333b8173eda3cebd4d1