### PR TITLE
Replace literal node kind with explicit kinds

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -18,7 +18,10 @@ typedef enum {
   NK_ExitStmt,
   NK_Unary,
   NK_Binary,
-  NK_Literal,
+  NK_Int,
+  NK_String,
+  NK_Bool,
+  NK_Identifier,
 } NodeKind;
 
 // Forward declarations

--- a/parser.c
+++ b/parser.c
@@ -96,13 +96,28 @@ static Node *parse_expr(Token **pp, int minbp); // forward declaration
 static Node *nud(Token **pp) {
   Token *tok = peek(pp);
   switch (tok->type) {
-  case INT:
-  case STRING:
-  case BOOL:
+  case INT: {
+    next(pp);
+    Node *node = init_node(NULL, tok->value, tok->type);
+    node->kind = NK_Int;
+    return node;
+  }
+  case STRING: {
+    next(pp);
+    Node *node = init_node(NULL, tok->value, tok->type);
+    node->kind = NK_String;
+    return node;
+  }
+  case BOOL: {
+    next(pp);
+    Node *node = init_node(NULL, tok->value, tok->type);
+    node->kind = NK_Bool;
+    return node;
+  }
   case IDENTIFIER: {
     next(pp);
     Node *node = init_node(NULL, tok->value, tok->type);
-    node->kind = NK_Literal;
+    node->kind = NK_Identifier;
     return node;
   }
   case OPEN_PAREN: {
@@ -195,6 +210,7 @@ static Node *parse_let(Token **pp, bool expect_semi) {
   Node *node = init_node(NULL, NULL, 0);
   node->kind = NK_LetStmt;
   Node *id_node = init_node(NULL, id->value, IDENTIFIER);
+  id_node->kind = NK_Identifier;
   node->left = id_node;
   if (match(pp, ASSIGNMENT)) {
     Node *expr = parse_expr(pp, 0);
@@ -215,7 +231,9 @@ static Node *parse_assign_or_expr(Token **pp) {
     Node *node = init_node(NULL, NULL, 0);
     node->kind = NK_AssignStmt;
     node->op = t;
-    node->left = init_node(NULL, start->value, IDENTIFIER);
+    Node *id_node = init_node(NULL, start->value, IDENTIFIER);
+    id_node->kind = NK_Identifier;
+    node->left = id_node;
     node->right = expr;
     return node;
   }

--- a/sem.c
+++ b/sem.c
@@ -65,29 +65,24 @@ static void sem_error(const char *msg, const char *name) {
   exit(1);
 }
 
-static Type *token_to_type(TokenType t) {
-  switch (t) {
-  case INT:    return type_int();
-  case STRING: return type_string();
-  case BOOL:   return type_bool();
-  default:     return type_unknown();
-  }
-}
-
 Type *sem_expr(Node *node, Scope *scope) {
   if (!node) return type_void();
   switch (node->kind) {
-  case NK_Literal:
-    if (node->type == IDENTIFIER) {
-      Type *t = scope_lookup(scope, node->value);
-      if (!t) sem_error("undeclared identifier", node->value);
-      node->ty = t;
-      return t;
-    } else {
-      Type *t = token_to_type(node->type);
-      node->ty = t;
-      return t;
-    }
+  case NK_Int:
+    node->ty = type_int();
+    return node->ty;
+  case NK_String:
+    node->ty = type_string();
+    return node->ty;
+  case NK_Bool:
+    node->ty = type_bool();
+    return node->ty;
+  case NK_Identifier: {
+    Type *t = scope_lookup(scope, node->value);
+    if (!t) sem_error("undeclared identifier", node->value);
+    node->ty = t;
+    return t;
+  }
   case NK_Unary: {
     Type *rt = sem_expr(node->left, scope);
     switch (node->op) {


### PR DESCRIPTION
## Summary
- Replace `NK_Literal` with `NK_Int`, `NK_String`, `NK_Bool`, and `NK_Identifier`
- Update parser to emit these node kinds and mark identifiers in declarations and assignments
- Adjust semantic analysis for the new literal node kinds

## Testing
- `./build.sh`
- `./build_asan.sh`
- `./build/hsc test_cases/hello_world.hs`


------
https://chatgpt.com/codex/tasks/task_e_68a9fe5353b08333b4c696458e73cd6f