### PR TITLE
Refactor for-loop parsing into structured node

### DIFF
--- a/codegen.c
+++ b/codegen.c
@@ -16,11 +16,13 @@ static void emit_exit(Node *node, FILE *out) {
 
 static void emit_node(Node *node, FILE *out) {
     if (!node) return;
-    if (node->type == EXIT) {
+    if (node->kind == NK_ExitStmt) {
         emit_exit(node, out);
     }
     emit_node(node->left, out);
     emit_node(node->right, out);
+    for (size_t i = 0; i < node->children.len; i++)
+        emit_node(node->children.items[i], out);
 }
 
 void generate_code(Node *root, const char *filename) {


### PR DESCRIPTION
## Summary
- Parse `for` loops into a structured `NK_ForStmt` node with optional init/cond/step clauses
- Add semantic analysis for `for` loops and ensure loop scope
- Traverse AST children in codegen so loop bodies and other constructs are visited

## Testing
- `./build.sh`
- `./build/hsc /tmp/for_test.hs`

------
https://chatgpt.com/codex/tasks/task_e_68aa00571ccc8333b1d85abc6b56c153