### PR TITLE
Refactor if-statement AST layout

### DIFF
--- a/sem.c
+++ b/sem.c
@@ -231,11 +231,11 @@ int sem_block(Node *block, Scope *scope) {
 }
 
 static int sem_if(Node *ifnode, Scope *scope) {
-  if (sem_expr(ifnode->children.items[0], scope) != type_bool())
+  if (sem_expr(ifnode->left, scope) != type_bool())
     sem_error("if condition must be boolean", NULL);
-  int exit_then = sem_block(ifnode->children.items[1], scope);
-  if (ifnode->children.len > 2) {
-    Node *alt = ifnode->children.items[2];
+  int exit_then = sem_block(ifnode->right, scope);
+  if (ifnode->children.len > 0) {
+    Node *alt = ifnode->children.items[0];
     int exit_alt;
     if (alt->kind == NK_IfStmt)
       exit_alt = sem_if(alt, scope);


### PR DESCRIPTION
## Summary
- Store `if` condition and then-block in `node->left` and `node->right`
- Preserve optional `else`/`else if` as a single child node
- Update tree printer and semantic analysis to work with new layout

## Testing
- `./build.sh`
- `build/hsc test_cases/conditionals.hs`
- `build/hsc test_cases/if_elif_else.hs` *(fails: Semantic error: undeclared identifier 'value')*

------
https://chatgpt.com/codex/tasks/task_e_68aa01dfd294833390cb874e43e09883