### PR TITLE
Add expression statement node and unify statement semantics

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -9,6 +9,7 @@ typedef enum {
   NK_Program,
   NK_Block,
   NK_FnDecl,
+  NK_ExprStmt,
   NK_LetStmt,
   NK_AssignStmt,
   NK_IfStmt,


### PR DESCRIPTION
## Summary
- Add `NK_ExprStmt` node kind and wrap bare expressions as statement nodes
- Store identifiers directly on `LetStmt`/`AssignStmt` nodes for clearer AST
- Extend semantic analysis to handle `ExprStmt`, `LetStmt`, and `AssignStmt`

## Testing
- `./build.sh`
- `./build/hsc /tmp/test_expr.hs`


------
https://chatgpt.com/codex/tasks/task_e_68aa031733948333985401c8d80fd209