### PR TITLE
Add assignment expression node and unify statement parsing

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -19,6 +19,7 @@ typedef enum {
   NK_ExitStmt,
   NK_Unary,
   NK_Binary,
+  NK_Assign,   // assignment expression
   NK_Int,
   NK_String,
   NK_Bool,

--- a/tests/cases/assign_chain.ast
+++ b/tests/cases/assign_chain.ast
@@ -17,6 +17,6 @@ Program
         FnDecl value=main
             Block
                 LetStmt value=a
-                    Binary op==
+                    Assign op==
                         Identifier value=b
                         Int value=5

--- a/tests/cases/for_min.ast
+++ b/tests/cases/for_min.ast
@@ -40,13 +40,13 @@ Program
                 LetStmt value=i
                     Int value=0
                 ForStmt
-                    AssignStmt op== value=i
+                    AssignStmt op==
                         Identifier value=i
                         Int value=0
                     Binary op=<
                         Identifier value=i
                         Int value=3
-                    AssignStmt op== value=i
+                    AssignStmt op==
                         Identifier value=i
                         Binary op=+
                             Identifier value=i


### PR DESCRIPTION
## Summary
- introduce `NK_Assign` for assignment expressions
- parse assignment operators as right-associative and produce `Assign` nodes
- simplify statement parsing with `expr_to_stmt` and adjust test fixtures

## Testing
- `./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ab5e5502148333b4d9048cde81c220