### PR TITLE
Support postfix increment in for-loop steps

### DIFF
--- a/tests/cases/for_inc.ast
+++ b/tests/cases/for_inc.ast
@@ -1,0 +1,16 @@
+Printing AST (Abstract Syntax Tree):
+Program
+    Block
+        FnDecl value=main
+            Block
+                ForStmt
+                    LetStmt value=i
+                        Int value=0
+                    Binary op=<
+                        Identifier value=i
+                        Int value=3
+                    Unary op=++
+                        Identifier value=i
+                    Block
+                        WriteStmt
+                            Identifier value=i

--- a/tests/cases/for_inc.hsc
+++ b/tests/cases/for_inc.hsc
@@ -1,0 +1,5 @@
+fn main() {
+  for (let i=0; i<3; i++) {
+    write(i);
+  }
+}


### PR DESCRIPTION
## Summary
- handle postfix ++/-- with no right operand in expression parser
- add nosemi helper to keep ++/-- in for-loop steps
- test for `for (let i=0; i<3; i++) { write(i); }`

## Testing
- `./runtests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ab6bad6150833390f68519814d7296