### PR TITLE
Add parser tests for while, exit, and string concatenation

### DIFF
--- a/tests/cases/exit_stmt.ast
+++ b/tests/cases/exit_stmt.ast
@@ -1,0 +1,9 @@
+Printing AST (Abstract Syntax Tree):
+Program
+    Block
+        FnDecl value: main
+            Block
+                WriteStmt
+                    String value: before exit
+                ExitStmt
+                    Int value: 0

--- a/tests/cases/exit_stmt.hsc
+++ b/tests/cases/exit_stmt.hsc
@@ -1,0 +1,4 @@
+fn main() {
+  write("before exit");
+  exit(0);
+}

--- a/tests/cases/string_concat.ast
+++ b/tests/cases/string_concat.ast
@@ -1,0 +1,11 @@
+Printing AST (Abstract Syntax Tree):
+Program
+    Block
+        FnDecl value: main
+            Block
+                LetStmt value: s
+                    Binary op: +
+                        String value: hsu
+                        String value: Script
+                WriteStmt
+                    Identifier value: s

--- a/tests/cases/string_concat.hsc
+++ b/tests/cases/string_concat.hsc
@@ -1,0 +1,4 @@
+fn main() {
+  let s = "hsu" + "Script";
+  write(s);
+}

--- a/tests/cases/while_basic.ast
+++ b/tests/cases/while_basic.ast
@@ -1,0 +1,19 @@
+Printing AST (Abstract Syntax Tree):
+Program
+    Block
+        FnDecl value: main
+            Block
+                LetStmt value: i
+                    Int value: 0
+                WhileStmt
+                    Binary op: <
+                        Identifier value: i
+                        Int value: 2
+                    Block
+                        WriteStmt
+                            Identifier value: i
+                        AssignStmt op: = value: i
+                            Identifier value: i
+                            Binary op: +
+                                Identifier value: i
+                                Int value: 1

--- a/tests/cases/while_basic.hsc
+++ b/tests/cases/while_basic.hsc
@@ -1,0 +1,7 @@
+fn main() {
+  let i = 0;
+  while (i < 2) {
+    write(i);
+    i = i + 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add while loop test covering assignment and binary comparison
- cover exit() syscall with literal argument
- test string concatenation in let binding

## Testing
- `./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ab82527f40833395511188f60ef56c