### PR TITLE
Emit Intel syntax and rodata for main

### DIFF
--- a/main.c
+++ b/main.c
@@ -53,11 +53,13 @@ int main(int argc, char *argv[]) {
 
   sem_program(root);
 
-  FILE *outf = fopen("out.s", "w");
-  Codegen *cg = codegen_create(outf);
-  codegen_program(cg, root);
-  codegen_free(cg);
-  fclose(outf);
+  if (!ast_only) {
+    FILE *outf = fopen("out.s", "w");
+    Codegen *cg = codegen_create(outf);
+    codegen_program(cg, root);
+    codegen_free(cg);
+    fclose(outf);
+  }
   free_tree(root);
 
 }


### PR DESCRIPTION
## Summary
- Generate `.intel_syntax noprefix` header with `.text` and `.globl main`
- Emit only the `main` function body and produce `.rodata` with `.asciz` strings
- Skip code generation during `--ast-only` runs

## Testing
- `./runtests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68abccd540808333b4cb890fb38ce9d0