### PR TITLE
Add runtime printing helpers and asm check script

### DIFF
--- a/runtime/rt.c
+++ b/runtime/rt.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+
+void hsu_print_cstr(const char *s) {
+    if (s) {
+        puts(s);
+    } else {
+        puts("(null)");
+    }
+}
+
+void hsu_print_int(long n) {
+    printf("%ld\n", n);
+}
+

--- a/tools/asm_check.sh
+++ b/tools/asm_check.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Compile assembly snippets and link with the runtime.
+set -euo pipefail
+
+# Run from repository root
+cd "$(dirname "$0")/.."
+
+BUILD_DIR=build
+RT_SRC=runtime/rt.c
+RT_OBJ="$BUILD_DIR/rt.o"
+
+mkdir -p "$BUILD_DIR"
+
+# Compile runtime exactly once per script invocation
+echo "  CC  $RT_SRC"
+gcc -Iinclude -Wall -Wextra -c "$RT_SRC" -o "$RT_OBJ"
+
+# Optionally compile and link any assembly files provided as arguments
+for asm in "$@"; do
+  base="$(basename "$asm")"
+  obj="$BUILD_DIR/${base%.s}.o"
+  exe="$BUILD_DIR/${base%.s}"
+  echo "  AS  $asm"
+  gcc -c "$asm" -o "$obj"
+  echo "  LD  $exe"
+  gcc "$obj" "$RT_OBJ" -o "$exe"
+done


### PR DESCRIPTION
## Summary
- Introduce simple runtime library with string and integer print helpers
- Provide asm_check.sh to compile the runtime into `build/rt.o` and link assembly snippets

## Testing
- `./build.sh`
- `./tools/asm_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68abe13707948333bb441b6f6fb9bd9a