### PR TITLE
refactor: relocate scripts and harden asm checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ hsuScript is a toy compiler written in C.
 Compile the project with:
 
 ```bash
-./build.sh
+./tools/build.sh
 ```
 
-The executable is placed at `build/hsc`. AddressSanitizer build is available via `./build_asan.sh`.
+The executable is placed at `build/hsc`. AddressSanitizer build is available via `./tools/build_asan.sh`.
 
 ## Running
 
@@ -37,7 +37,7 @@ See `test_cases/` for examples.
 Run the parser fixtures with:
 
 ```bash
-./runtests.sh
+./tools/runtests.sh
 ```
 
 The script builds the compiler and checks each `.hsc` in `tests/cases` against its expected `.ast` or `.err` output.

--- a/tools/asm_check.sh
+++ b/tools/asm_check.sh
@@ -12,16 +12,51 @@ RT_OBJ="$BUILD_DIR/rt.o"
 mkdir -p "$BUILD_DIR"
 
 # Compile runtime exactly once per script invocation
+if [[ ! -f "$RT_SRC" ]]; then
+  echo "missing runtime source: $RT_SRC" >&2
+  exit 1
+fi
 echo "  CC  $RT_SRC"
 gcc -Iinclude -Wall -Wextra -c "$RT_SRC" -o "$RT_OBJ"
 
-# Optionally compile and link any assembly files provided as arguments
+GREEN='\e[32m'
+RED='\e[31m'
+RESET='\e[0m'
+status=0
+
+# Optionally compile, link, and run any assembly files provided as arguments
 for asm in "$@"; do
   base="$(basename "$asm")"
   obj="$BUILD_DIR/${base%.s}.o"
   exe="$BUILD_DIR/${base%.s}"
+
+  if [[ ! -f "$asm" ]]; then
+    printf '%b %s\n' "${RED}[FAIL]${RESET}" "$asm (missing file)"
+    status=1
+    continue
+  fi
+
   echo "  AS  $asm"
-  gcc -c "$asm" -o "$obj"
+  if ! gcc -c "$asm" -o "$obj"; then
+    printf '%b %s\n' "${RED}[FAIL]${RESET}" "$asm (assemble)"
+    status=1
+    continue
+  fi
+
   echo "  LD  $exe"
-  gcc "$obj" "$RT_OBJ" -o "$exe"
+  if ! gcc "$obj" "$RT_OBJ" -o "$exe"; then
+    printf '%b %s\n' "${RED}[FAIL]${RESET}" "$asm (link)"
+    status=1
+    continue
+  fi
+
+  if "$exe" >/dev/null 2>&1; then
+    printf '%b %s\n' "${GREEN}[PASS]${RESET}" "$asm"
+  else
+    printf '%b %s\n' "${RED}[FAIL]${RESET}" "$asm (run)"
+    status=1
+  fi
 done
+
+exit $status
+

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd "$(dirname "$0")"
+cd "$(dirname "$0")/.."
 
 mkdir -p build
 

--- a/tools/build_asan.sh
+++ b/tools/build_asan.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # always run from repo root (directory of this script)
-cd "$(dirname "$0")"
+cd "$(dirname "$0")/.."
 
 # choose compiler (override with: CC=clang ./build_asan.sh)
 CC="${CC:-gcc}"

--- a/tools/run_all_tests.sh
+++ b/tools/run_all_tests.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
+cd "$(dirname "$0")/.."
 
 echo "===== Running language tests ====="
-./runtests.sh
+./tools/runtests.sh
 
 echo "===== Running assembly checks ====="
 ./tools/asm_check.sh "$@"

--- a/tools/runtests.sh
+++ b/tools/runtests.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # ultra-minimal runner
 set -u
-cd "$(dirname "$0")"
+cd "$(dirname "$0")/.."
 
 echo "Building..."
-./build.sh || { echo "Build failed"; exit 1; }
+./tools/build.sh || { echo "Build failed"; exit 1; }
 echo "Build OK."
 
 # Discover tests robustly
@@ -37,9 +37,9 @@ for case_path in "${cases[@]}"; do
     fi
 
     if diff -q <(strip_trailing "$exp_ast") <(strip_trailing "$tmp") >/dev/null && [[ $rc -eq 0 ]]; then
-      echo "[PASS] $name"; ((passed++))
+      printf '\e[32m[PASS]\e[0m %s\n' "$name"; ((passed++))
     else
-      echo "[FAIL] $name"; ((failed++))
+      printf '\e[31m[FAIL]\e[0m %s\n' "$name"; ((failed++))
       # uncomment to inspect:
       # sed -n '1,120p' "$tmp"
     fi
@@ -48,15 +48,15 @@ for case_path in "${cases[@]}"; do
     if ./build/hsc --ast-only "$case_path" >"$tmp" 2>&1; then rc=0; else rc=$?; fi
     expected_rc="$(cat "$exp_exit")"
     if diff -q <(strip_trailing "$exp_err") <(strip_trailing "$tmp") >/dev/null && [[ "$rc" == "$expected_rc" ]]; then
-      echo "[PASS] $name"; ((passed++))
+      printf '\e[32m[PASS]\e[0m %s\n' "$name"; ((passed++))
     else
-      echo "[FAIL] $name"; ((failed++))
+      printf '\e[31m[FAIL]\e[0m %s\n' "$name"; ((failed++))
       # echo "rc=$rc expected=$expected_rc"
       # sed -n '1,120p' "$tmp"
     fi
 
   else
-    echo "[FAIL] $name (no .ast or .err/.exit oracle)"; ((failed++))
+    printf '\e[31m[FAIL]\e[0m %s (no .ast or .err/.exit oracle)\n' "$name"; ((failed++))
   fi
 
   ((total++))


### PR DESCRIPTION
## Summary
- move build and test scripts under tools
- add colored PASS/FAIL output and improve asm_check robustness

## Testing
- `./tools/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68abf6d009b483339f6d2b2d72783aaa