### PR TITLE
Use caller-saved register for binary ops

### DIFF
--- a/codegen.c
+++ b/codegen.c
@@ -251,41 +251,41 @@ static void gen_expr(Codegen *cg, Node *node) {
         gen_expr(cg, node->left);
         emit(cg, "    push rax\n");
         gen_expr(cg, node->right);
-        emit(cg, "    mov rbx, rax\n    pop rax\n");
+        emit(cg, "    mov r10, rax\n    pop rax\n");
 
         switch (node->op) {
         case PLUS:
-            emit(cg, "    add rax, rbx\n");
+            emit(cg, "    add rax, r10\n");
             break;
         case DASH:
-            emit(cg, "    sub rax, rbx\n");
+            emit(cg, "    sub rax, r10\n");
             break;
         case STAR:
-            emit(cg, "    imul rax, rbx\n");
+            emit(cg, "    imul rax, r10\n");
             break;
         case SLASH:
-            emit(cg, "    cqo\n    idiv rbx\n");
+            emit(cg, "    cqo\n    idiv r10\n");
             break;
         case PERCENT:
-            emit(cg, "    cqo\n    idiv rbx\n    mov rax, rdx\n");
+            emit(cg, "    cqo\n    idiv r10\n    mov rax, rdx\n");
             break;
         case EQUALS:
-            emit(cg, "    cmp rax, rbx\n    sete al\n    movzx rax, al\n");
+            emit(cg, "    cmp rax, r10\n    sete al\n    movzx rax, al\n");
             break;
         case NOT_EQUALS:
-            emit(cg, "    cmp rax, rbx\n    setne al\n    movzx rax, al\n");
+            emit(cg, "    cmp rax, r10\n    setne al\n    movzx rax, al\n");
             break;
         case LESS:
-            emit(cg, "    cmp rax, rbx\n    setl al\n    movzx rax, al\n");
+            emit(cg, "    cmp rax, r10\n    setl al\n    movzx rax, al\n");
             break;
         case LESS_EQUALS:
-            emit(cg, "    cmp rax, rbx\n    setle al\n    movzx rax, al\n");
+            emit(cg, "    cmp rax, r10\n    setle al\n    movzx rax, al\n");
             break;
         case GREATER:
-            emit(cg, "    cmp rax, rbx\n    setg al\n    movzx rax, al\n");
+            emit(cg, "    cmp rax, r10\n    setg al\n    movzx rax, al\n");
             break;
         case GREATER_EQUALS:
-            emit(cg, "    cmp rax, rbx\n    setge al\n    movzx rax, al\n");
+            emit(cg, "    cmp rax, r10\n    setge al\n    movzx rax, al\n");
             break;
         default:
             break;
@@ -487,7 +487,7 @@ void codegen_program(Codegen *cg, Node *program) {
     emit_node(cg, main_fn, &has_exit);
 
     if (cg->strs.len > 0) {
-        emit(cg, ".rodata\n");
+        emit(cg, ".section .rodata\n");
         for (size_t i = 0; i < cg->strs.len; i++) {
             const char *s = cg->strs.items[i];
             emit(cg, ".Lstr%zu: .asciz \"", i);


### PR DESCRIPTION
## Summary
- Avoid clobbering callee-saved registers by using `r10` for binary operation temporaries
- Emit string literals in `.section .rodata` for successful assembly

## Testing
- `./tools/asm_check.sh build/hello.s build/while_basic.s build/for_dec.s build/for_inc.s build/for_min.s build/string_concat.s`

------
https://chatgpt.com/codex/tasks/task_e_68abfe2dae9c8333b108651cc48f0972