### PR TITLE
Refactor if-statement AST to use children array

### DIFF
--- a/codegen.c
+++ b/codegen.c
@@ -443,17 +443,20 @@ static void emit_node(Codegen *cg, Node *node, bool *has_exit) {
         emit_exit(cg, node, has_exit);
         break;
     case NK_IfStmt: {
+        Node *cond = node->children.len > 0 ? node->children.items[0] : NULL;
+        Node *then_block = node->children.len > 1 ? node->children.items[1] : NULL;
+        Node *else_node = node->children.len > 2 ? node->children.items[2] : NULL;
         int l_else = new_label(cg);
         int l_end = new_label(cg);
-        if (node->left)
-            gen_expr(cg, node->left);
+        if (cond)
+            gen_expr(cg, cond);
         emit(cg, "    cmp rax, 0\n    je .L%d\n", l_else);
-        if (node->right)
-            emit_node(cg, node->right, has_exit);
+        if (then_block)
+            emit_node(cg, then_block, has_exit);
         emit(cg, "    jmp .L%d\n", l_end);
         emit(cg, ".L%d:\n", l_else);
-        if (node->children.len > 0)
-            emit_node(cg, node->children.items[0], has_exit);
+        if (else_node)
+            emit_node(cg, else_node, has_exit);
         emit(cg, ".L%d:\n", l_end);
         break;
     }

--- a/parser.c
+++ b/parser.c
@@ -362,8 +362,8 @@ static Node *parse_if_internal(Token **pp, bool consumed_kw) {
   Node *cond = parse_expr(pp, 0);
   expect(pp, CLOSE_PAREN, "expected )");
   Node *then_block = parse_block(pp);
-  node->left = cond;
-  node->right = then_block;
+  vec_push(&node->children, cond);
+  vec_push(&node->children, then_block);
   if (match(pp, ELSE_IF)) {
     Node *elif = parse_if_internal(pp, true);
     vec_push(&node->children, elif);

--- a/sem.c
+++ b/sem.c
@@ -227,13 +227,13 @@ int sem_block(Node *block, Scope *scope) {
 }
 
 static int sem_if(Node *ifnode, Scope *scope) {
-  Node *cond = ifnode->left;
-  Node *then_block = ifnode->right;
+  Node *cond = ifnode->children.len > 0 ? ifnode->children.items[0] : NULL;
+  Node *then_block = ifnode->children.len > 1 ? ifnode->children.items[1] : NULL;
+  Node *else_node = ifnode->children.len > 2 ? ifnode->children.items[2] : NULL;
   if (sem_expr(cond, scope) != type_bool())
     sem_error("if condition must be boolean", NULL);
   int exit_then = sem_block(then_block, scope);
-  if (ifnode->children.len > 0) {
-    Node *else_node = ifnode->children.items[0];
+  if (else_node) {
     int exit_alt;
     if (else_node->kind == NK_IfStmt)
       exit_alt = sem_if(else_node, scope);


### PR DESCRIPTION
## Summary
- store if-statement condition and then-block as first two children
- handle optional else/elif as third child during codegen and semantic analysis

## Testing
- `./tools/runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ac072d093483338bc11e5f14d9e7b1