### PR TITLE
Implement prefix vs postfix semantics for ++/--

### DIFF
--- a/codegen.c
+++ b/codegen.c
@@ -248,16 +248,18 @@ static void gen_expr(Codegen *cg, Node *node) {
             break;
         case PLUS_PLUS:
         case MINUS_MINUS: {
-            /* treat both prefix and postfix the same for now */
             if (node->left && node->left->kind == NK_Identifier) {
                 int off = sym_lookup(cg, node->left->value, NULL);
                 if (off >= 0) {
-                    emit(cg, "    mov rax, [rbp - %d]\n", off);
+                    if (node->postfix)
+                        emit(cg, "    mov rcx, rax\n");
                     if (node->op == PLUS_PLUS)
                         emit(cg, "    add rax, 1\n");
                     else
                         emit(cg, "    sub rax, 1\n");
                     emit(cg, "    mov [rbp - %d], rax\n", off);
+                    if (node->postfix)
+                        emit(cg, "    mov rax, rcx\n");
                 }
             }
             break;

--- a/include/parser.h
+++ b/include/parser.h
@@ -2,6 +2,7 @@
 #define PARSER_H
 
 
+#include <stdbool.h>
 #include "lexer.h"
 
 // Kinds of AST nodes that may appear in the syntax tree.
@@ -49,6 +50,7 @@ typedef struct Node {
   struct Node *right;
   struct Node *left;
   Vec children;      // Used when this node represents a block
+  bool postfix;      // true if ++/-- appears in postfix form
   Type *ty;          // Inferred semantic type
 } Node;
 

--- a/parser.c
+++ b/parser.c
@@ -115,6 +115,7 @@ Node *init_node(Node *node, const char *value, TokenType type) {
   node->children.items = NULL;
   node->children.len = 0;
   node->children.cap = 0;
+  node->postfix = false;
   node->ty = NULL;
   return node;
 }
@@ -230,6 +231,7 @@ static Node *nud(Token **pp) {
     node->kind = NK_Unary;
     node->op = op;
     node->left = right;
+    node->postfix = false;
     return node;
   }
   default:
@@ -257,6 +259,7 @@ static Node *parse_expr(Token **pp, int minbp) {
       node->kind = NK_Unary;
       node->op = op;
       node->left = left;
+      node->postfix = true;
       left = node;
       continue;
     }


### PR DESCRIPTION
## Summary
- Track whether ++/-- is used in postfix form in AST nodes
- Parse and code generate correct values for pre- and post-increment/decrement

## Testing
- `./tools/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ac0e7f9a7c8333a77b40840fecdeab