### PR TITLE
Emit runtime extern directives before text segment

### DIFF
--- a/codegen.c
+++ b/codegen.c
@@ -584,6 +584,14 @@ void codegen_program(Codegen *cg, Node *program) {
     }
 
     emit(cg, ".intel_syntax noprefix\n");
+    static bool externs_emitted = false;
+    if (!externs_emitted) {
+        emit(cg, ".extern hsu_print_int\n");
+        emit(cg, ".extern hsu_print_cstr\n");
+        emit(cg, ".extern hsu_concat\n");
+        emit(cg, ".extern exit\n");
+        externs_emitted = true;
+    }
     emit(cg, ".text\n");
     emit(cg, ".globl main\n");
 


### PR DESCRIPTION
## Summary
- Declare runtime helpers at top of generated assembly

## Testing
- `./tools/runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ac10d1d4b883339e600e430fd7c0ba