### PR TITLE
Add execution test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,12 @@ Run the parser fixtures with:
 ./tools/runtests.sh
 ```
 
-The script builds the compiler and checks each `.hsc` in `tests/cases` against its expected `.ast` or `.err` output.
+Run the full test suite, including executing compiled programs and
+verifying their stdout, with:
+
+```bash
+./tools/run_all_tests.sh
+```
+
+These scripts build the compiler, check each `.hsc` in `tests/cases`
+against its expected output, and report results to stdout.

--- a/tools/run_all_tests.sh
+++ b/tools/run_all_tests.sh
@@ -5,6 +5,10 @@ cd "$(dirname "$0")/.."
 echo "===== Running language tests ====="
 ./tools/runtests.sh
 
-echo "===== Running assembly checks ====="
-./tools/asm_check.sh "$@"
-exit $?
+echo "===== Running execution tests ====="
+./tools/runexec.sh
+
+if (( "$#" )); then
+  echo "===== Running assembly checks ====="
+  ./tools/asm_check.sh "$@"
+fi

--- a/tools/runexec.sh
+++ b/tools/runexec.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Compile sources to assembly, link with runtime, and verify program output.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Build compiler
+echo "Building..."
+if ! ./tools/build.sh > /dev/null; then
+  echo "Build failed" >&2
+  exit 1
+fi
+
+# Compile runtime once
+BUILD_DIR=build
+RT_SRC=runtime/rt.c
+RT_OBJ="$BUILD_DIR/rt.o"
+mkdir -p "$BUILD_DIR"
+
+echo "Compiling runtime..."
+if ! gcc -Iinclude -Wall -Wextra -c "$RT_SRC" -o "$RT_OBJ"; then
+  echo "Failed to compile runtime" >&2
+  exit 1
+fi
+
+strip_trailing() { sed -E 's/[[:space:]]+$//' "$1"; }
+
+# Discover all .hsc test cases
+mapfile -d '' -t cases < <(find tests/cases -type f -name '*.hsc' -print0 | sort -z)
+echo "Discovered ${#cases[@]} case(s):"
+for c in "${cases[@]}"; do echo "  $c"; done
+(( ${#cases[@]} > 0 )) || { echo "No .hsc tests found."; exit 1; }
+
+passed=0
+failed=0
+total=0
+
+for case_path in "${cases[@]}"; do
+  name="$(basename "$case_path" .hsc)"
+  exp_out="tests/cases/$name.out"
+  exp_exit="tests/cases/$name.exit"
+  asm="$BUILD_DIR/$name.s"
+  obj="$BUILD_DIR/$name.o"
+  exe="$BUILD_DIR/$name"
+
+  # Only run execution tests when both .out and .exit oracles exist
+  if [[ -f "$exp_out" && -f "$exp_exit" ]]; then
+    if ! ./build/hsc --emit-asm "$asm" "$case_path" >/dev/null 2>&1; then
+      printf '\e[31m[FAIL]\e[0m %s (emit)\n' "$name"
+      failed=$((failed+1))
+      total=$((total+1))
+      continue
+    fi
+
+    if ! gcc -c "$asm" -o "$obj"; then
+      printf '\e[31m[FAIL]\e[0m %s (assemble)\n' "$name"
+      failed=$((failed+1))
+      total=$((total+1))
+      continue
+    fi
+
+    if ! gcc "$obj" "$RT_OBJ" -o "$exe"; then
+      printf '\e[31m[FAIL]\e[0m %s (link)\n' "$name"
+      failed=$((failed+1))
+      total=$((total+1))
+      continue
+    fi
+
+    tmp="$(mktemp)"
+    if "$exe" >"$tmp"; then
+      rc=0
+    else
+      rc=$?
+    fi
+
+    expected_rc="$(cat "$exp_exit")"
+    if diff -q <(strip_trailing "$exp_out") <(strip_trailing "$tmp") >/dev/null && [[ "$rc" == "$expected_rc" ]]; then
+      printf '\e[32m[PASS]\e[0m %s\n' "$name"
+      passed=$((passed+1))
+    else
+      printf '\e[31m[FAIL]\e[0m %s\n' "$name"
+      failed=$((failed+1))
+    fi
+    rm -f "$tmp"
+    total=$((total+1))
+  fi
+
+done
+
+echo "----------------------------------------------------------------------"
+echo "Total: $total   Passed: $passed   Failed: $failed"
+[[ $failed -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary
- add `runexec.sh` to build programs, emit assembly, link runtime, and validate stdout/exit codes
- wire execution testing into `run_all_tests.sh`
- document new test scripts in README

## Testing
- `./tools/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ac1202941c833396730b07753ef1b9