### PR TITLE
Align rodata strings and escape more characters

### DIFF
--- a/codegen.c
+++ b/codegen.c
@@ -600,6 +600,7 @@ void codegen_program(Codegen *cg, Node *program) {
 
     if (cg->strs.len > 0) {
         emit(cg, ".section .rodata\n");
+        emit(cg, ".p2align 4\n");
         for (size_t i = 0; i < cg->strs.len; i++) {
             const char *s = cg->strs.items[i];
             emit(cg, ".Lstr%zu: .asciz \"", i);
@@ -608,6 +609,10 @@ void codegen_program(Codegen *cg, Node *program) {
                     emit(cg, "\\%c", *p);
                 else if (*p == '\n')
                     emit(cg, "\\n");
+                else if (*p == '\t')
+                    emit(cg, "\\t");
+                else if (*p == '\r')
+                    emit(cg, "\\r");
                 else
                     emit(cg, "%c", *p);
             }


### PR DESCRIPTION
## Summary
- align string table to 16 bytes before emitting strings
- escape tab and carriage return characters in string constants

## Testing
- `./tools/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ac13e5265883339ba895972f60b622