### PR TITLE
Use node_name helper for identifier diagnostics

### DIFF
--- a/codegen.c
+++ b/codegen.c
@@ -232,7 +232,7 @@ static void gen_expr(Codegen *cg, Node *node) {
             emit(cg, "    mov rax, [rbp - %d]\n", off);
         } else {
             fprintf(stderr, "codegen: unknown symbol %s\n",
-                    node->value ? node->value : "<null>");
+                    node_name(node));
             exit(1);
         }
         break;
@@ -283,7 +283,7 @@ static void gen_expr(Codegen *cg, Node *node) {
                 sym_set_string(cg, off, is_str);
             } else {
                 fprintf(stderr, "codegen: unknown symbol %s\n",
-                        name ? name : "<null>");
+                        node_name(node->left));
                 exit(1);
             }
         }
@@ -393,7 +393,7 @@ static void emit_node(Codegen *cg, Node *node, bool *has_exit) {
         scope_pop(cg);
         break;
     case NK_FnDecl: {
-        const char *name = node->value ? node->value : "<null>";
+        const char *name = node_name(node);
         Node *body = node->children.len > 0 ? node->children.items[0] : NULL;
         int locals = count_locals(body);
         int frame = locals * 8;
@@ -451,7 +451,7 @@ static void emit_node(Codegen *cg, Node *node, bool *has_exit) {
             sym_set_string(cg, off, is_str);
         } else {
             fprintf(stderr, "codegen: unknown symbol %s\n",
-                    name ? name : "<null>");
+                    node_name(node->left));
             exit(1);
         }
         break;

--- a/include/parser.h
+++ b/include/parser.h
@@ -58,6 +58,9 @@ typedef struct Node {
 Node *init_node(Node *node, const char *value, TokenType type);
 void free_tree(Node *node);
 
+// Returns the identifier name for a node or "<null>" if absent.
+const char *node_name(const Node *node);
+
 Node *parser(Token *tokens);
 void print_tree(Node *node, int indent);
 

--- a/parser.c
+++ b/parser.c
@@ -120,6 +120,11 @@ Node *init_node(Node *node, const char *value, TokenType type) {
   return node;
 }
 
+// Return the node's identifier name or "<null>" if none.
+const char *node_name(const Node *node) {
+  return (node && node->value) ? node->value : "<null>";
+}
+
 // --- tree printer ----------------------------------------------------------
 void print_tree(Node *node, int indent) {
   if (!node)
@@ -134,7 +139,7 @@ void print_tree(Node *node, int indent) {
     printf(" op: %s", op_name(node->op));
 
   if (node->value)
-    printf(" value: %s", node->value);
+    printf(" value: %s", node_name(node));
 
   printf("\n");
 

--- a/sem.c
+++ b/sem.c
@@ -76,7 +76,7 @@ Type *sem_expr(Node *node, Scope *scope) {
     return node->ty = type_bool();
   case NK_Identifier: {
     Type *t = scope_lookup(scope, node->value);
-    if (!t) sem_error("undeclared identifier", node->value);
+    if (!t) sem_error("undeclared identifier", node_name(node));
     return node->ty = t;
   }
   case NK_Unary: {
@@ -158,7 +158,7 @@ static void sem_let(Node *stmt, Scope *scope) {
   if (stmt->right)
     t = sem_expr(stmt->right, scope);
   if (!scope_insert(scope, name, t))
-    sem_error("duplicate identifier", name);
+    sem_error("duplicate identifier", node_name(stmt));
   stmt->ty = type_void();
 }
 
@@ -169,9 +169,9 @@ static void sem_assign(Node *stmt, Scope *scope) {
   else
     sem_error("assignment missing identifier", NULL);
   Type *lhs = scope_lookup(scope, name);
-  if (!lhs) sem_error("undeclared identifier", name);
+  if (!lhs) sem_error("undeclared identifier", node_name(stmt->left));
   Type *rhs = sem_expr(stmt->right, scope);
-  if (lhs != rhs) sem_error("assignment of incompatible types", name);
+  if (lhs != rhs) sem_error("assignment of incompatible types", node_name(stmt->left));
   stmt->ty = lhs;
 }
 


### PR DESCRIPTION
## Summary
- add `node_name` utility to safely report node identifiers
- use `node_name` in semantic and code generation diagnostics
- print AST values through `node_name` for clearer debug output

## Testing
- `./tools/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ac17eb81648333ad8e01a89715096a