### PR TITLE
Implement runtime string concatenation and link scripts

### DIFF
--- a/runtime/rt.c
+++ b/runtime/rt.c
@@ -17,12 +17,12 @@ void hsu_print_int(long n) {
 }
 
 char *hsu_concat(const char *a, const char *b) {
-    size_t la = a ? strlen(a) : 0;
-    size_t lb = b ? strlen(b) : 0;
-    char *res = malloc(la + lb + 1);
+    const char *sa = a ? a : "";
+    const char *sb = b ? b : "";
+    size_t len = strlen(sa) + strlen(sb) + 1;
+    char *res = malloc(len);
     if (!res) return NULL;
-    if (a) memcpy(res, a, la);
-    if (b) memcpy(res + la, b, lb);
-    res[la + lb] = '\0';
+    strcpy(res, sa);
+    strcat(res, sb);
     return res;
 }

--- a/tools/asm_check.sh
+++ b/tools/asm_check.sh
@@ -11,13 +11,15 @@ RT_OBJ="$BUILD_DIR/rt.o"
 
 mkdir -p "$BUILD_DIR"
 
-# Compile runtime exactly once per script invocation
+# Compile runtime if needed
 if [[ ! -f "$RT_SRC" ]]; then
   echo "missing runtime source: $RT_SRC" >&2
   exit 1
 fi
-echo "  CC  $RT_SRC"
-gcc -Iinclude -Wall -Wextra -c "$RT_SRC" -o "$RT_OBJ"
+if [[ ! -f "$RT_OBJ" || "$RT_SRC" -nt "$RT_OBJ" ]]; then
+  echo "  CC  $RT_SRC"
+  gcc -Iinclude -Wall -Wextra -c "$RT_SRC" -o "$RT_OBJ"
+fi
 
 GREEN='\e[32m'
 RED='\e[31m'

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -6,9 +6,10 @@ cd "$(dirname "$0")/.."
 mkdir -p build
 
 set -x
+gcc -Iinclude -Wall -Wextra -c runtime/rt.c -o build/rt.o
 gcc -Iinclude \
   -Wall -Wextra \
-  main.c lexer.c parser.c tools.c sem.c codegen.c \
+  main.c lexer.c parser.c tools.c sem.c codegen.c build/rt.o \
   -o build/hsc
 set +x
 


### PR DESCRIPTION
## Summary
- Implement `hsu_concat` using `malloc`, `strcpy`, and `strcat`
- Compile runtime into build products and reuse in asm check

## Testing
- `./tools/build.sh`
- `./tools/asm_check.sh build/test_concat.s`
- `./tools/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ac1a389f1c8333b9567e8ff35c98fe