### PR TITLE
Add module documentation and cross-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,22 @@ flowchart LR
 
 ```text
 .
+├── docs/          # module documentation
 ├── lexer.c        # tokenizes source code
 ├── parser.c       # builds the AST
+├── sem.c          # semantic analysis
 ├── codegen.c      # emits code
 ├── runtime/       # runtime support library
 ├── tests/         # parser and execution tests
 └── tools/         # build and test scripts
 ```
+
+Module guides:
+- [Lexer](docs/lexer.md)
+- [Parser](docs/parser.md)
+- [Semantics](docs/semantics.md)
+- [Code generation](docs/codegen.md)
+- [Runtime](docs/runtime.md)
 
 ## Quick Start
 

--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -1,0 +1,27 @@
+# Code Generation
+
+The code generator turns the typed AST into x86-64 assembly.
+
+## Data Structures
+- `Symbol` records a variable's name, stack-frame `offset`, and whether it holds a string.
+- `CGScope` is a stack of symbol tables mirroring lexical scopes.
+- `StrVec` stores deduplicated string literals for emission into the data section.
+- `Codegen` holds the output file handle along with state such as `next_label`, current `scope`, and stack tracking (`frame_size`, `stack_depth`).
+
+## Key Functions
+- `codegen_create`/`codegen_free` allocate and dispose of a `Codegen` instance.
+- `codegen_program` walks the AST and emits assembly for the `main` function.
+- Internal helpers like `gen_expr` and `emit_node` handle specific node kinds, while `scope_push`/`scope_pop` manage symbol scopes.
+
+## Example Workflow
+```c
+Codegen *cg = codegen_create(stdout);
+codegen_program(cg, program);
+codegen_free(cg);
+```
+
+## Extending
+To emit code for a new AST node:
+1. Extend `gen_expr` or `emit_node` with a case for the new `NodeKind`.
+2. Manage any new runtime calls or helper routines (e.g. add them to the runtime and emit the appropriate `call`).
+3. If new data types are involved, ensure symbols track any additional metadata needed by later stages.

--- a/docs/lexer.md
+++ b/docs/lexer.md
@@ -1,0 +1,27 @@
+# Lexer
+
+The lexer turns raw source code into a linear stream of tokens that the parser can consume.
+
+## Data Structures
+- `TokenType` enum categorizes lexemes (identifiers, literals, operators, keywords, etc.).
+- `Token` holds a token's `type`, string `value`, and originating `line_num`.
+
+## Key Functions
+- `lexer(FILE *file)` reads a file and returns a dynamically sized array of `Token` ending in `END_OF_TOKENS`.
+- `generate_number`, `generate_keyword_or_identifier`, `generate_string_token`, and `generate_separator_or_operator` create tokens for specific lexeme classes.
+- `print_token` is a debugging helper that displays token information.
+
+## Example Workflow
+```c
+FILE *f = fopen("program.hsc", "r");
+Token *toks = lexer(f);
+for (size_t i = 0; toks[i].type != END_OF_TOKENS; i++) {
+    print_token(toks[i]);
+}
+```
+
+## Extending
+To support a new lexical feature:
+1. Add the token to `TokenType`.
+2. Teach the main loop in `lexer.c` how to recognize it (possibly adding a new `generate_*` helper).
+3. Update the parser and later compiler stages to understand the new token.

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -1,0 +1,27 @@
+# Parser
+
+The parser consumes tokens and produces an abstract syntax tree (AST) describing the program.
+
+## Data Structures
+- `NodeKind` enumerates all possible AST node types (programs, statements, expressions, literals, etc.).
+- `Vec` is a growable array used to hold child nodes for block-like constructs.
+- `Node` represents a single AST node with its `kind`, optional token `type`, operator `op`, literal `value`, pointers `left`/`right`, and `children` vector.
+
+## Key Functions
+- `parser(Token *tokens)` builds an AST rooted at `NK_Program` from the token stream.
+- `init_node` allocates and initializes nodes; `free_tree` recursively releases them.
+- The Pratt parser helpers (`parse_expr`, `nud`, and `lbp`) handle expression parsing with proper precedence.
+- Statement helpers like `parse_if`, `parse_while`, and `parse_for` build control-flow constructs.
+
+## Example Workflow
+```c
+Token *toks = lexer(f);
+Node *program = parser(toks);
+print_tree(program, 0);   // visualize the AST
+```
+
+## Extending
+To introduce a new AST node:
+1. Add a value to `NodeKind` and update `kind_name` for debugging output.
+2. Write parsing logic that produces the new node (either in `nud`, `parse_expr`, or a statement helper).
+3. Update semantic analysis and code generation to handle the new node kind.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,0 +1,17 @@
+# Runtime
+
+The runtime library supplies helper functions that the generated assembly calls for I/O and string handling.
+
+## Functions
+- `hsu_print_cstr(const char *s)` prints a C string followed by a newline.
+- `hsu_print_int(long n)` prints an integer value.
+- `hsu_concat(const char *a, const char *b)` allocates and returns the concatenation of two strings.
+
+## Example Workflow
+These functions are compiled into a static library and linked with the code produced by `codegen`. For example, a `write("hi")` statement becomes a call to `hsu_print_cstr`.
+
+## Extending
+To add a new runtime capability:
+1. Implement the function in `runtime/rt.c` and declare it in `include/runtime.h`.
+2. Rebuild the runtime library via `tools/build.sh`.
+3. Update the code generator so that it emits calls to the new function when appropriate.

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -1,0 +1,28 @@
+# Semantic Analysis
+
+The semantic analyser performs type checking and scope resolution on the AST.
+
+## Data Structures
+- `TypeKind` defines the primitive types (`TY_INT`, `TY_STRING`, `TY_BOOL`, `TY_VOID`, `TY_UNKNOWN`).
+- `Type` is a simple wrapper around `TypeKind` used to annotate AST nodes.
+- `Binding` links an identifier name to its `Type` within a scope.
+- `Scope` forms a linked list of lexical scopes, each containing a chain of bindings.
+
+## Key Functions
+- `sem_expr` infers and validates the type of an expression node.
+- `sem_block` walks a block, managing a new scope and checking contained statements.
+- `sem_program` initializes the global scope and checks all top-level blocks.
+- Scope utilities (`scope_new`, `scope_lookup`, `scope_insert`) manage symbol tables.
+- Helper constructors like `type_int`, `type_string`, etc. provide singleton type objects.
+
+## Example Workflow
+```c
+Node *program = parser(toks);
+sem_program(program);   // annotates nodes and reports semantic errors
+```
+
+## Extending
+When adding new language features:
+1. Extend the type system if necessary by updating `TypeKind` and helper constructors.
+2. Teach `sem_expr` or `sem_block` how to validate the new AST node kinds.
+3. Ensure corresponding changes exist in the parser and code generator so that nodes receive the expected type information.


### PR DESCRIPTION
## Summary
- document lexer, parser, semantics, codegen, and runtime modules
- cross-link new docs from README project structure

## Testing
- `./tools/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ac3123e424833388f9e22912dd1001