### PR TITLE
Embed runtime object into compiler

### DIFF
--- a/main.c
+++ b/main.c
@@ -3,12 +3,28 @@
 #include <ctype.h>
 #include <string.h>
 #include <sys/wait.h>
+#include <stddef.h>
 
 #include "lexer.h"
 #include "parser.h"
 #include "tools.h"
 #include "codegen.h"
 #include "sem.h"
+
+extern unsigned char rt_o_start[];
+extern unsigned char rt_o_end[];
+
+static int dump_runtime(const char *path) {
+  FILE *f = fopen(path, "wb");
+  if (!f) return -1;
+  size_t size = (size_t)(rt_o_end - rt_o_start);
+  if (fwrite(rt_o_start, 1, size, f) != size) {
+    fclose(f);
+    return -1;
+  }
+  fclose(f);
+  return 0;
+}
 
 void print_tokens(Token *t) {
   size_t i = 0;
@@ -35,6 +51,16 @@ int main(int argc, char *argv[]) {
       } else {
         argi++;
       }
+    } else if (strcmp(argv[argi], "--dump-rt") == 0) {
+      if (argc <= argi + 1) {
+        fprintf(stderr, "--dump-rt requires a path\n");
+        return 1;
+      }
+      if (dump_runtime(argv[argi + 1]) != 0) {
+        fprintf(stderr, "ERROR: could not write runtime object\n");
+        return 1;
+      }
+      return 0;
     } else {
       break;
     }
@@ -90,9 +116,15 @@ int main(int argc, char *argv[]) {
   codegen_free(cg);
   fclose(outf);
 
+  if (dump_runtime("build/rt_tmp.o") != 0) {
+    fprintf(stderr, "ERROR: failed to write runtime object\n");
+    free_tree(root);
+    return 1;
+  }
+
   if (run_bin) {
     if (system("gcc -Wa,--noexecstack -c build/out.s -o build/out.o") != 0 ||
-        system("gcc build/out.o build/rt.o -o build/out") != 0) {
+        system("gcc build/out.o build/rt_tmp.o -o build/out") != 0) {
       fprintf(stderr, "ERROR: failed to build binary\n");
       free_tree(root);
       return 1;

--- a/tools/asm_check.sh
+++ b/tools/asm_check.sh
@@ -6,19 +6,13 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 BUILD_DIR=build
-RT_SRC=runtime/rt.c
-RT_OBJ="$BUILD_DIR/rt.o"
+RT_OBJ="$BUILD_DIR/rt_tmp.o"
 
 mkdir -p "$BUILD_DIR"
 
-# Compile runtime if needed
-if [[ ! -f "$RT_SRC" ]]; then
-  echo "missing runtime source: $RT_SRC" >&2
+if ! ./build/hsc --dump-rt "$RT_OBJ" >/dev/null; then
+  echo "failed to dump runtime object" >&2
   exit 1
-fi
-if [[ ! -f "$RT_OBJ" || "$RT_SRC" -nt "$RT_OBJ" ]]; then
-  echo "  CC  $RT_SRC"
-  gcc -Iinclude -Wall -Wextra -c "$RT_SRC" -o "$RT_OBJ"
 fi
 
 GREEN='\e[32m'

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -7,9 +7,14 @@ mkdir -p build
 
 set -x
 gcc -Iinclude -Wall -Wextra -c runtime/rt.c -o build/rt.o
+ld -r -b binary build/rt.o -o build/rt_blob.o
+objcopy --redefine-sym _binary_build_rt_o_start=rt_o_start \
+        --redefine-sym _binary_build_rt_o_end=rt_o_end \
+        --redefine-sym _binary_build_rt_o_size=rt_o_size \
+        build/rt_blob.o build/rt_embed.o
 gcc -Iinclude \
   -Wall -Wextra \
-  main.c lexer.c parser.c tools.c sem.c codegen.c build/rt.o \
+  main.c lexer.c parser.c tools.c sem.c codegen.c build/rt_embed.o \
   -o build/hsc
 set +x
 

--- a/tools/runexec.sh
+++ b/tools/runexec.sh
@@ -10,15 +10,8 @@ if ! ./tools/build.sh > /dev/null; then
 fi
 
 BUILD_DIR=build
-RT_SRC=runtime/rt.c
-RT_OBJ="$BUILD_DIR/rt.o"
+RT_OBJ="$BUILD_DIR/rt_tmp.o"
 mkdir -p "$BUILD_DIR"
-
-echo "Compiling runtime..."
-if ! gcc -Iinclude -Wall -Wextra -c "$RT_SRC" -o "$RT_OBJ"; then
-  echo "Failed to compile runtime" >&2
-  exit 1
-fi
 
 # Discover all .hsc test cases under tests/exec
 mapfile -d '' -t cases < <(find tests/exec -type f -name '*.hsc' -print0 | sort -z)


### PR DESCRIPTION
## Summary
- Embed `runtime/rt.c` into the compiler as a binary blob and link it into `hsc`
- Allow `hsc` to dump the embedded runtime via `--dump-rt` and automatically write a temporary `rt_tmp.o` for compilation
- Update scripts to rely on the embedded runtime rather than building `rt.o`

## Testing
- `./tools/build.sh`
- `./tools/runexec.sh`
- `./tools/asm_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ac338eceb08333a1e8da31df5ba60b