### PR TITLE
Add compile-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Module guides:
    ./build/hsc path/to/file.hsc
    ```
 
+## Command-line options
+
+- `--ast-only`: parse and print the AST without generating code
+- `--emit-asm [path]`: write assembly to `path` (defaults to `build/out.s`)
+- `--compile [output]`: produce a binary named `output` (defaults to `a.out`) without running it
+
 ## Testing
 
 Run parser fixtures:


### PR DESCRIPTION
## Summary
- add `--compile [output]` flag to emit and link a standalone binary without running it
- document command-line options in README

## Testing
- `./tools/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ac34e8f0a8833384480a2347823bae